### PR TITLE
set up scalafix tasks in afterEvaluate so custom source sets are picked up

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ plugins {
 }
 ```
 
->**NOTE:** this plugin requires the `scala` plugin to be explicitly applied prior to it, otherwise it will complain.
-
 
 &nbsp;
 ## Selecting Rules

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use the Scalafix plugin, please include the following snippet in your build s
 buildscript {
     repositories {
         maven {
-            url  "https://dl.bintray.com/cosmicsilence/maven" // soon in Maven Central :)
+            url  "https://dl.bintray.com/cosmicsilence/maven" // soon on the Gradle Plugin Portal :)
         }
     }
     dependencies {

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -25,17 +25,18 @@ class ScalafixPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        if (!project.plugins.hasPlugin(ScalaPlugin)) {
-            throw new GradleException("'scala' plugin must be applied before 'scalafix'")
-        }
 
         def extension = project.extensions.create(EXTENSION, ScalafixExtension, project)
         def customRulesConfiguration = project.configurations.create(CUSTOM_RULES_CONFIGURATION)
         customRulesConfiguration.description = "Dependencies containing custom Scalafix rules"
 
-        configureTasks(project, extension)
-
         project.afterEvaluate {
+            if (!project.plugins.hasPlugin(ScalaPlugin)) {
+                throw new GradleException("The 'scala' plugin must be applied")
+            }
+
+            configureTasks(project, extension)
+
             if (extension.autoConfigureSemanticdb) {
                 configureSemanticdbCompilerPlugin(project)
             }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -69,7 +69,6 @@ class ScalafixPlugin implements Plugin<Project> {
         task.description = "${mainTask.description} in '${sourceSet.getName()}'"
         task.group = mainTask.group
         task.source = sourceSet.allScala.matching {
-            // This is applied after evaluating the project
             include(extension.includes.get())
             exclude(extension.excludes.get())
         }
@@ -79,10 +78,9 @@ class ScalafixPlugin implements Plugin<Project> {
             prop.split('\\s*,\\s*').findAll { !it.isEmpty() }.toList()
         }))
         mainTask.dependsOn task
-        project.afterEvaluate {
-            if (extension.autoConfigureSemanticdb) {
-                task.dependsOn project.tasks.getByName(sourceSet.getCompileTaskName('scala'))
-            }
+
+        if (extension.autoConfigureSemanticdb) {
+            task.dependsOn project.tasks.getByName(sourceSet.getCompileTaskName('scala'))
         }
     }
 

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -10,13 +10,13 @@ import spock.lang.Specification
 class ScalafixPluginFunctionalTest extends Specification {
 
     @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
-    private File settingsFile;
-    private File buildFile;
+    public final TemporaryFolder testProjectDir = new TemporaryFolder()
+    private File settingsFile
+    private File buildFile
 
     def setup() {
-        settingsFile = testProjectDir.newFile("settings.gradle");
-        buildFile = testProjectDir.newFile("build.gradle");
+        settingsFile = testProjectDir.newFile("settings.gradle")
+        buildFile = testProjectDir.newFile("build.gradle")
 
         buildFile.write'''
 plugins {
@@ -70,6 +70,44 @@ scalafix { autoConfigureSemanticdb = false }'''
         !buildResult.output.contains(':compileTestScala SKIPPED')
         buildResult.output.contains(':scalafixMain SKIPPED')
         buildResult.output.contains(':scalafixTest SKIPPED')
+    }
+
+    def 'scalafix<SourceSet> task is created and runs compile<SourceSet>Scala by default when additional source set exists in the build script'() {
+        given:
+        buildFile.append '''
+sourceSets {
+    integTest { }
+}'''
+
+        when:
+        BuildResult buildResult = runGradleTask('scalafix', ['-m'])
+
+        then:
+        buildResult.output.contains(':compileScala SKIPPED')
+        buildResult.output.contains(':compileTestScala SKIPPED')
+        buildResult.output.contains(':compileIntegTestScala SKIPPED')
+        buildResult.output.contains(':scalafixMain SKIPPED')
+        buildResult.output.contains(':scalafixTest SKIPPED')
+        buildResult.output.contains(':scalafixIntegTest SKIPPED')
+    }
+
+    def 'checkScalafix<SourceSet> task is created and runs compile<SourceSet>Scala by default when additional source set exists in the build script'() {
+        given:
+        buildFile.append '''
+sourceSets {
+    integTest { }
+}'''
+
+        when:
+        BuildResult buildResult = runGradleTask('checkScalafix', ['-m'])
+
+        then:
+        buildResult.output.contains(':compileScala SKIPPED')
+        buildResult.output.contains(':compileTestScala SKIPPED')
+        buildResult.output.contains(':compileIntegTestScala SKIPPED')
+        buildResult.output.contains(':checkScalafixMain SKIPPED')
+        buildResult.output.contains(':checkScalafixTest SKIPPED')
+        buildResult.output.contains(':checkScalafixIntegTest SKIPPED')
     }
 
     BuildResult runGradleTask(String task, List<String> arguments) {

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -19,10 +19,10 @@ class ScalafixPluginTest extends Specification {
 
     def 'The plugin adds the scalafix configuration, tasks and extension to the project'() {
         given:
-        project.pluginManager.apply 'scala'
+        applyScalafixPlugin(project)
 
         when:
-        project.pluginManager.apply ScalafixPlugin
+        project.evaluate()
 
         then:
         project.tasks.scalafix
@@ -36,15 +36,18 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'The plugin throws an exception if when applied, the scala plugin has not been applied to the project'() {
-        when:
+        given:
         project.pluginManager.apply 'io.github.cosmicsilence.scalafix'
+
+        when:
+        project.evaluate()
 
         then:
         thrown GradleException
     }
 
     def 'The plugin adds the semanticdb plugin config to the compiler options when autoConfigureSemanticdb is set to true'() {
-        setup:
+        given:
         applyScalafixPlugin(project, true)
 
         when:
@@ -67,7 +70,7 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'Semanticdb configuration is not added if autoConfigureSemanticdb is set to false'() {
-        setup:
+        given:
         applyScalafixPlugin(project, false)
 
         when:
@@ -79,9 +82,11 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'checkScalafix task configuration validation'() {
+        given:
+        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+
         when:
-        applyScalafixPlugin(project, false, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        project.evaluate()
 
         then:
         Task task = project.tasks.getByName('checkScalafix')
@@ -91,9 +96,8 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'checkScalafixMain task configuration validation'() {
-        setup:
-        applyScalafixPlugin(project, false, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        given:
+        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
 
         when:
         project.evaluate()
@@ -107,9 +111,8 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'checkScalafixMain task configuration validation when autoConfigureSemanticDb is enabled'() {
-        setup:
-        applyScalafixPlugin(project, true, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        given:
+        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
 
         when:
         project.evaluate()
@@ -123,9 +126,8 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'checkScalafixTest task configuration validation'() {
-        setup:
-        applyScalafixPlugin(project, false, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        given:
+        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
 
         when:
         project.evaluate()
@@ -139,9 +141,8 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'checkScalafixTest task configuration validation when autoConfigureSemanticDb is enabled'() {
-        setup:
-        applyScalafixPlugin(project, true, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        given:
+        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
 
         when:
         project.evaluate()
@@ -155,9 +156,11 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'scalafix task configuration validation'() {
+        given:
+        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+
         when:
-        applyScalafixPlugin(project, false, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        project.evaluate()
 
         then:
         Task task = project.tasks.getByName('scalafix')
@@ -167,9 +170,8 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'scalafixMain task configuration validation'() {
-        setup:
-        applyScalafixPlugin(project, false, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        given:
+        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
 
         when:
         project.evaluate()
@@ -183,9 +185,8 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'scalafixMain task configuration validation when autoConfigureSemanticDb is enabled'() {
-        setup:
-        applyScalafixPlugin(project, true, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        given:
+        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
 
         when:
         project.evaluate()
@@ -199,9 +200,8 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'scalafixTest task configuration validation'() {
-        setup:
-        applyScalafixPlugin(project, false, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        given:
+        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
 
         when:
         project.evaluate()
@@ -215,9 +215,8 @@ class ScalafixPluginTest extends Specification {
     }
 
     def 'scalafixTest task configuration validation when autoConfigureSemanticDb is enabled'() {
-        setup:
-        applyScalafixPlugin(project, true, 'Foo,Bar',
-                project.file('.scalafix.conf'))
+        given:
+        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
 
         when:
         project.evaluate()
@@ -228,6 +227,90 @@ class ScalafixPluginTest extends Specification {
         task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
         task.rules.get().contains('Foo')
         task.rules.get().contains('Bar')
+    }
+
+    def 'scalafix<SourceSet> task configuration validation when additional source set is present'() {
+        given:
+        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+        project.with {
+            sourceSets {
+                foo { }
+            }
+        }
+
+        when:
+        project.evaluate()
+
+        then:
+        ScalafixTask task = project.tasks.getByName('scalafixFoo')
+        task.dependsOn.isEmpty()
+        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
+        task.rules.get().contains('Foo')
+        task.rules.get().contains('Bar')
+        project.tasks.getByName('scalafix').dependsOn(task)
+    }
+
+    def 'scalafix<SourceSet> task configuration validation when additional source set is present and autoConfigureSemanticDb is enabled'() {
+        given:
+        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
+        project.with {
+            sourceSets {
+                bar { }
+            }
+        }
+
+        when:
+        project.evaluate()
+
+        then:
+        ScalafixTask task = project.tasks.getByName('scalafixBar')
+        task.dependsOn.find { it.name == 'compileBarScala' }
+        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
+        task.rules.get().contains('Foo')
+        task.rules.get().contains('Bar')
+        project.tasks.getByName('scalafix').dependsOn(task)
+    }
+
+    def 'checkScalafix<SourceSet> task configuration validation when additional source set is present'() {
+        given:
+        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+        project.with {
+            sourceSets {
+                foo { }
+            }
+        }
+
+        when:
+        project.evaluate()
+
+        then:
+        ScalafixTask task = project.tasks.getByName('checkScalafixFoo')
+        task.dependsOn.isEmpty()
+        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
+        task.rules.get().contains('Foo')
+        task.rules.get().contains('Bar')
+        project.tasks.getByName('checkScalafix').dependsOn(task)
+    }
+
+    def 'checkScalafix<SourceSet> task configuration validation when additional source set is present and autoConfigureSemanticDb is enabled'() {
+        given:
+        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
+        project.with {
+            sourceSets {
+                bar { }
+            }
+        }
+
+        when:
+        project.evaluate()
+
+        then:
+        ScalafixTask task = project.tasks.getByName('checkScalafixBar')
+        task.dependsOn.find { it.name == 'compileBarScala' }
+        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
+        task.rules.get().contains('Foo')
+        task.rules.get().contains('Bar')
+        project.tasks.getByName('checkScalafix').dependsOn(task)
     }
 
 //    def 'scalafix uses the .scalafix config file from the subproject by default'() {
@@ -256,11 +339,11 @@ class ScalafixPluginTest extends Specification {
 //        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
 //    }
 
-    private applyScalafixPlugin(Project project, Boolean autoConfigureSemanticDb = true,
+    private applyScalafixPlugin(Project project, Boolean autoConfigureSemanticDb = false,
                                 String rules = '', File configFile = project.file('.scalafix.conf')) {
         project.with {
             apply plugin: 'scala'
-            apply plugin: ScalafixPlugin
+            apply plugin: 'io.github.cosmicsilence.scalafix'
 
             repositories {
                 mavenCentral()


### PR DESCRIPTION
Scalafix tasks are not being created for custom source sets added to the build script. Task creation logic is now moved into the project.afterEvaluate phase.