### PR TITLE
Scalafixconf file resolution refactoring and scalafix task mode property changed to gradle task input

### DIFF
--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
@@ -6,6 +6,8 @@ import org.gradle.api.provider.SetProperty
 
 class ScalafixExtension {
 
+    private static final String DEFAULT_CONFIG_FILE = ".scalafix.conf"
+
     /**
      * Scalafix configuration file. If not specified, the plugin will try to find
      * a file named '.scalafix.conf' in the project's directory and then in the
@@ -37,7 +39,10 @@ class ScalafixExtension {
 
     ScalafixExtension(Project project) {
         this.project = project
-        configFile = project.objects.fileProperty()
+        configFile = project.objects.fileProperty().convention(
+                project.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE).asFile.exists()?
+                        project.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE) :
+                        project.rootProject.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE))
         includes = project.objects.setProperty(String)
         excludes = project.objects.setProperty(String)
     }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
@@ -39,10 +39,17 @@ class ScalafixExtension {
 
     ScalafixExtension(Project project) {
         this.project = project
-        configFile = project.objects.fileProperty().convention(
-                project.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE).asFile.exists()?
-                        project.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE) :
-                        project.rootProject.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE))
+        configFile = project.objects.fileProperty()
+
+        def projectConfigFile = project.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE)
+        def rootProjectConfigFile = project.rootProject.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE)
+
+        if (projectConfigFile.asFile.exists()) {
+            configFile = project.objects.fileProperty().convention(projectConfigFile)
+        } else if (rootProjectConfigFile.asFile.exists()) {
+            configFile = project.objects.fileProperty().convention(rootProjectConfigFile)
+        }
+
         includes = project.objects.setProperty(String)
         excludes = project.objects.setProperty(String)
     }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
@@ -1,6 +1,7 @@
 package io.github.cosmicsilence.scalafix
 
 import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.SetProperty
 
@@ -41,17 +42,15 @@ class ScalafixExtension {
         this.project = project
         configFile = project.objects.fileProperty()
 
-        def projectConfigFile = project.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE)
-        def rootProjectConfigFile = project.rootProject.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE)
-
-        if (projectConfigFile.asFile.exists()) {
-            configFile = project.objects.fileProperty().convention(projectConfigFile)
-        } else if (rootProjectConfigFile.asFile.exists()) {
-            configFile = project.objects.fileProperty().convention(rootProjectConfigFile)
-        }
-
+        configFile = project.objects.fileProperty().convention(
+                locateConfigFile(project) ?: locateConfigFile(project.rootProject))
         includes = project.objects.setProperty(String)
         excludes = project.objects.setProperty(String)
+    }
+
+    private RegularFile locateConfigFile(Project project) {
+        def configFile = project.getLayout().getProjectDirectory().file(DEFAULT_CONFIG_FILE)
+        return (configFile.asFile.exists() && configFile.asFile.isFile()) ? configFile : null
     }
 
     /**

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -69,7 +69,6 @@ class ScalafixPlugin implements Plugin<Project> {
             description = "${mainTask.description} in '${sourceSet.getName()}'"
             group = mainTask.group
             source = sourceSet.allScala.matching {
-                // This is applied after evaluating the project
                 include(extension.includes.get())
                 exclude(extension.excludes.get())
             }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -60,23 +60,27 @@ class ScalafixPlugin implements Plugin<Project> {
     }
 
     private void configureTaskForSourceSet(SourceSet sourceSet,
-                                           ScalafixMainMode mode,
+                                           ScalafixMainMode taskMode,
                                            Task mainTask,
                                            Project project,
                                            ScalafixExtension extension) {
         def name = mainTask.name + sourceSet.name.capitalize()
-        def task = project.tasks.create(name, ScalafixTask, mode)
-        task.description = "${mainTask.description} in '${sourceSet.getName()}'"
-        task.group = mainTask.group
-        task.source = sourceSet.allScala.matching {
-            include(extension.includes.get())
-            exclude(extension.excludes.get())
+        def task = project.tasks.create(name, ScalafixTask) {
+            description = "${mainTask.description} in '${sourceSet.getName()}'"
+            group = mainTask.group
+            source = sourceSet.allScala.matching {
+                // This is applied after evaluating the project
+                include(extension.includes.get())
+                exclude(extension.excludes.get())
+            }
+            configFile = extension.configFile
+            rules.set(project.provider({
+                String prop = project.findProperty(RULES_PROPERTY) ?: ""
+                prop.split('\\s*,\\s*').findAll { !it.isEmpty() }.toList()
+            }))
+            mode = taskMode
         }
-        task.configFile = extension.configFile
-        task.rules.set(project.provider({
-            String prop = project.findProperty(RULES_PROPERTY) ?: ""
-            prop.split('\\s*,\\s*').findAll { !it.isEmpty() }.toList()
-        }))
+
         mainTask.dependsOn task
 
         if (extension.autoConfigureSemanticdb) {

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
@@ -36,6 +36,7 @@ class ScalafixTask extends SourceTask {
 
     private void processSources() {
         def sourcePaths = source.collect { it.toPath() }
+        def config = java.util.Optional.ofNullable(configFile.get()).map { it.asFile.toPath() }
         def cliDependency = project.dependencies.create(BuildInfo.scalafixCliArtifact)
         def cliClasspath = project.configurations.detachedConfiguration(cliDependency)
         def customRulesClasspath = project.configurations.getByName(ScalafixPlugin.CUSTOM_RULES_CONFIGURATION)
@@ -61,7 +62,7 @@ class ScalafixTask extends SourceTask {
         def args = Scalafix.classloadInstance(cliClassloader)
                 .newArguments()
                 .withMode(mode)
-                .withConfig(configFile)
+                .withConfig(config)
                 .withRules(rules.get())
                 .withSourceroot(project.projectDir.toPath())
                 .withPaths(sourcePaths)

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
@@ -10,14 +10,11 @@ import org.gradle.api.tasks.scala.ScalaCompile
 import scalafix.interfaces.Scalafix
 import scalafix.interfaces.ScalafixMainMode
 
-import javax.inject.Inject
 import java.nio.file.Path
 
 class ScalafixTask extends SourceTask {
 
     private static final Logger logger = Logging.getLogger(ScalafixTask)
-
-    private final ScalafixMainMode mode
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -28,10 +25,8 @@ class ScalafixTask extends SourceTask {
     @Optional
     final ListProperty<String> rules = project.objects.listProperty(String)
 
-    @Inject
-    ScalafixTask(ScalafixMainMode mode) {
-        this.mode = mode
-    }
+    @Input
+    ScalafixMainMode mode
 
     @TaskAction
     void run() {

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
@@ -1,6 +1,5 @@
 package io.github.cosmicsilence.scalafix
 
-import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
@@ -17,7 +16,6 @@ import java.nio.file.Path
 class ScalafixTask extends SourceTask {
 
     private static final Logger logger = Logging.getLogger(ScalafixTask)
-    private static final String DEFAULT_CONFIG_FILE = ".scalafix.conf"
 
     private final ScalafixMainMode mode
 
@@ -43,7 +41,6 @@ class ScalafixTask extends SourceTask {
 
     private void processSources() {
         def sourcePaths = source.collect { it.toPath() }
-        def configFile = resolveConfigFile()
         def cliDependency = project.dependencies.create(BuildInfo.scalafixCliArtifact)
         def cliClasspath = project.configurations.detachedConfiguration(cliDependency)
         def customRulesClasspath = project.configurations.getByName(ScalafixPlugin.CUSTOM_RULES_CONFIGURATION)
@@ -117,16 +114,5 @@ class ScalafixTask extends SourceTask {
     private static URLClassLoader classloaderFrom(Configuration configuration, ClassLoader parent) {
         def jars = configuration.collect { it.toURI().toURL() }.toArray(new URL[0])
         new URLClassLoader(jars, parent)
-    }
-
-    // FIXME: this needs to be resolved in configuration time
-    private java.util.Optional<Path> resolveConfigFile() {
-        def defaultConfig = { Project proj ->
-            def file = proj.file(DEFAULT_CONFIG_FILE)
-            if (file.exists() && file.isFile()) file.toPath() else null
-        }
-
-        def file = configFile.map { it.asFile.toPath() }.orNull ?: defaultConfig(project) ?: defaultConfig(project.rootProject)
-        java.util.Optional.ofNullable(file)
     }
 }

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -4,6 +4,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
+import scalafix.interfaces.ScalafixMainMode
 import spock.lang.Specification
 
 class ScalafixPluginTest extends Specification {
@@ -124,6 +125,7 @@ class ScalafixPluginTest extends Specification {
         task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
         task.rules.get().contains('Foo')
         task.rules.get().contains('Bar')
+        task.mode == ScalafixMainMode.CHECK
     }
 
     def 'checkScalafixMain task configuration validation when autoConfigureSemanticDb is enabled'() {
@@ -139,6 +141,7 @@ class ScalafixPluginTest extends Specification {
         task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
         task.rules.get().contains('Foo')
         task.rules.get().contains('Bar')
+        task.mode == ScalafixMainMode.CHECK
     }
 
     def 'checkScalafixTest task configuration validation'() {
@@ -154,6 +157,7 @@ class ScalafixPluginTest extends Specification {
         task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
         task.rules.get().contains('Foo')
         task.rules.get().contains('Bar')
+        task.mode == ScalafixMainMode.CHECK
     }
 
     def 'checkScalafixTest task configuration validation when autoConfigureSemanticDb is enabled'() {
@@ -169,6 +173,7 @@ class ScalafixPluginTest extends Specification {
         task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
         task.rules.get().contains('Foo')
         task.rules.get().contains('Bar')
+        task.mode == ScalafixMainMode.CHECK
     }
 
     def 'scalafix task configuration validation'() {
@@ -198,6 +203,7 @@ class ScalafixPluginTest extends Specification {
         task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
         task.rules.get().contains('Foo')
         task.rules.get().contains('Bar')
+        task.mode == ScalafixMainMode.IN_PLACE
     }
 
     def 'scalafixMain task configuration validation when autoConfigureSemanticDb is enabled'() {
@@ -213,6 +219,7 @@ class ScalafixPluginTest extends Specification {
         task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
         task.rules.get().contains('Foo')
         task.rules.get().contains('Bar')
+        task.mode == ScalafixMainMode.IN_PLACE
     }
 
     def 'scalafixTest task configuration validation'() {
@@ -228,6 +235,7 @@ class ScalafixPluginTest extends Specification {
         task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
         task.rules.get().contains('Foo')
         task.rules.get().contains('Bar')
+        task.mode == ScalafixMainMode.IN_PLACE
     }
 
     def 'scalafixTest task configuration validation when autoConfigureSemanticDb is enabled'() {
@@ -243,6 +251,7 @@ class ScalafixPluginTest extends Specification {
         task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
         task.rules.get().contains('Foo')
         task.rules.get().contains('Bar')
+        task.mode == ScalafixMainMode.IN_PLACE
     }
 
     def 'scalafix<SourceSet> task configuration validation when additional source set is present'() {

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -387,7 +387,20 @@ class ScalafixPluginTest extends Specification {
 
         then:
         ScalafixTask task = subproject.tasks.getByName('checkScalafixMain')
-        !task.configFile.isPresent()
+    }
+
+    def 'scalafix does not use any scalafix.conf file as it is not provided'() {
+        given:
+        Project subproject = ProjectBuilder.builder().withParent(project).withName('the-subproject').build()
+        scalafixConf.delete()
+        applyScalafixPlugin(subproject, false, '', null)
+
+        when:
+        subproject.evaluate()
+
+        then:
+        ScalafixTask task = subproject.tasks.getByName('checkScalafixMain')
+        !task.configFile.get()
     }
 
     private applyScalafixPlugin(Project project, Boolean autoConfigureSemanticDb = false,

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -353,7 +353,6 @@ class ScalafixPluginTest extends Specification {
         subproject.evaluate()
 
         then:
-        println subproject.tasks
         ScalafixTask task = subproject.tasks.getByName('checkScalafixMain')
         task.configFile.get().asFile.path == "${subproject.projectDir}/.test-scalafix.conf"
     }

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -387,7 +387,7 @@ class ScalafixPluginTest extends Specification {
 
         then:
         ScalafixTask task = subproject.tasks.getByName('checkScalafixMain')
-        task.configFile.get().asFile.path == "${subproject.rootProject.projectDir}/.scalafix.conf"
+        !task.configFile.isPresent()
     }
 
     private applyScalafixPlugin(Project project, Boolean autoConfigureSemanticDb = false,


### PR DESCRIPTION
- .scalafix.conf file resolution logic is moved into the plugin extension
- scalafix task mode property changed to gradle task input