### PR TITLE
turn scalaVersion/compileOptions/classpath/sourceRoot into task inputs + fix NPE

### DIFF
--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -84,7 +84,7 @@ class ScalafixPlugin implements Plugin<Project> {
                 prop.split('\\s*,\\s*').findAll { !it.isEmpty() }.toList()
             }))
             mode = taskMode
-            classpath = (sourceSet.output.classesDirs + sourceSet.compileClasspath)
+            classpath = (sourceSet.output.classesDirs + sourceSet.compileClasspath).files.toList()
             scalaVersion = scalaJar ? scalaRuntime.getScalaVersion(scalaJar) : ''
             compileOptions = compileTask.scalaCompileOptions.additionalParameters ?: []
         }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -84,7 +84,7 @@ class ScalafixPlugin implements Plugin<Project> {
                 prop.split('\\s*,\\s*').findAll { !it.isEmpty() }.toList()
             }))
             mode = taskMode
-            classpath = compileTask.classpath
+            classpath = (sourceSet.output.classesDirs + sourceSet.compileClasspath)
             scalaVersion = scalaJar ? scalaRuntime.getScalaVersion(scalaJar) : ''
             compileOptions = compileTask.scalaCompileOptions.additionalParameters ?: []
         }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.scala.ScalaPlugin
+import org.gradle.api.tasks.ScalaRuntime
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.scala.ScalaCompile
 import scalafix.interfaces.ScalafixMainMode
@@ -35,11 +36,11 @@ class ScalafixPlugin implements Plugin<Project> {
                 throw new GradleException("The 'scala' plugin must be applied")
             }
 
-            configureTasks(project, extension)
-
             if (extension.autoConfigureSemanticdb) {
                 configureSemanticdbCompilerPlugin(project)
             }
+
+            configureTasks(project, extension)
         }
     }
 
@@ -64,26 +65,33 @@ class ScalafixPlugin implements Plugin<Project> {
                                            Task mainTask,
                                            Project project,
                                            ScalafixExtension extension) {
+        ScalaCompile compileTask = project.tasks.getByName(sourceSet.getCompileTaskName('scala'))
+        def scalaRuntime = project.extensions.findByType(ScalaRuntime)
+        def scalaJar = scalaRuntime.findScalaJar(compileTask.classpath, 'library')
+
         def name = mainTask.name + sourceSet.name.capitalize()
         def task = project.tasks.create(name, ScalafixTask) {
             description = "${mainTask.description} in '${sourceSet.getName()}'"
             group = mainTask.group
+            sourceRoot = project.projectDir
             source = sourceSet.allScala.matching {
                 include(extension.includes.get())
                 exclude(extension.excludes.get())
             }
             configFile = extension.configFile
             rules.set(project.provider({
-                String prop = project.findProperty(RULES_PROPERTY) ?: ""
+                String prop = project.findProperty(RULES_PROPERTY) ?: ''
                 prop.split('\\s*,\\s*').findAll { !it.isEmpty() }.toList()
             }))
             mode = taskMode
+            classpath = compileTask.classpath
+            scalaVersion = scalaJar ? scalaRuntime.getScalaVersion(scalaJar) : ''
+            compileOptions = compileTask.scalaCompileOptions.additionalParameters ?: []
         }
-
         mainTask.dependsOn task
 
         if (extension.autoConfigureSemanticdb) {
-            task.dependsOn project.tasks.getByName(sourceSet.getCompileTaskName('scala'))
+            task.dependsOn compileTask
         }
     }
 
@@ -91,9 +99,9 @@ class ScalafixPlugin implements Plugin<Project> {
         def dependency = project.dependencies.create(BuildInfo.semanticdbArtifact)
         def configuration = project.configurations.detachedConfiguration(dependency)
         def compilerParameters = [
-                "-Xplugin:" + configuration.asPath,
-                "-P:semanticdb:sourceroot:" + project.projectDir,
-                "-Yrangepos"
+                '-Xplugin:' + configuration.asPath,
+                '-P:semanticdb:sourceroot:' + project.projectDir,
+                '-Yrangepos'
         ]
 
         project.tasks.withType(ScalaCompile) { ScalaCompile task ->

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
@@ -1,23 +1,20 @@
 package io.github.cosmicsilence.scalafix
 
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.*
-import org.gradle.api.tasks.scala.ScalaCompile
 import scalafix.interfaces.Scalafix
 import scalafix.interfaces.ScalafixMainMode
-
-import java.nio.file.Path
 
 class ScalafixTask extends SourceTask {
 
     private static final Logger logger = Logging.getLogger(ScalafixTask)
 
     @InputFile
-    @PathSensitive(PathSensitivity.RELATIVE)
     @Optional
     final RegularFileProperty configFile = project.objects.fileProperty()
 
@@ -28,6 +25,21 @@ class ScalafixTask extends SourceTask {
     @Input
     ScalafixMainMode mode
 
+    @Input
+    @Optional
+    String scalaVersion
+
+    @Input
+    @Optional
+    List<String> compileOptions
+
+    @Input
+    @Optional
+    FileCollection classpath
+
+    @Input
+    File sourceRoot
+
     @TaskAction
     void run() {
         if (!source.isEmpty()) processSources()
@@ -36,45 +48,44 @@ class ScalafixTask extends SourceTask {
 
     private void processSources() {
         def sourcePaths = source.collect { it.toPath() }
-        def config = java.util.Optional.ofNullable(configFile.getOrNull()).map { it.asFile.toPath() }
+        def configPath = java.util.Optional.ofNullable(configFile.getOrNull()).map { it.asFile.toPath() }
+        def projectClasspath = classpath.collect { it.toPath() }
         def cliDependency = project.dependencies.create(BuildInfo.scalafixCliArtifact)
         def cliClasspath = project.configurations.detachedConfiguration(cliDependency)
         def customRulesClasspath = project.configurations.getByName(ScalafixPlugin.CUSTOM_RULES_CONFIGURATION)
-        def scalacVersion = getScalaVersion()
-        def scalacOptions = getScalacOptions()
-        def projectClasspath = getProjectClasspath()
 
         logger.debug(
-                """Initialising Scalafix with the following parameters:
+                """Running Scalafix with the following arguments:
                   | - Mode: ${mode}
                   | - Config file: ${configFile}
                   | - Custom rules classpath: ${customRulesClasspath.asPath}
-                  | - Scala version: ${scalacVersion}
-                  | - Scalac options: ${scalacOptions}
+                  | - Scala version: ${scalaVersion}
+                  | - Scalac options: ${compileOptions}
+                  | - Source root: ${sourceRoot}
                   | - Sources: ${sourcePaths}
                   | - Classpath: ${projectClasspath}
                   |""".stripMargin())
 
         def interfacesClassloader = new InterfacesClassloader(getClass().classLoader)
         def cliClassloader = classloaderFrom(cliClasspath, interfacesClassloader)
-        def toolsClassloader = classloaderFrom(customRulesClasspath, cliClassloader)
+        def customRulesClassloader = classloaderFrom(customRulesClasspath, cliClassloader)
 
         def args = Scalafix.classloadInstance(cliClassloader)
                 .newArguments()
                 .withMode(mode)
-                .withConfig(config)
+                .withConfig(configPath)
                 .withRules(rules.get())
-                .withSourceroot(project.projectDir.toPath())
+                .withSourceroot(sourceRoot.toPath())
                 .withPaths(sourcePaths)
-                .withToolClasspath(toolsClassloader)
+                .withToolClasspath(customRulesClassloader)
                 .withClasspath(projectClasspath)
-                .withScalaVersion(getScalaVersion())
-                .withScalacOptions(getScalacOptions())
+                .withScalaVersion(scalaVersion)
+                .withScalacOptions(compileOptions)
 
         logger.debug(
-                """Scalafix initialised!:
-                  | - Rules available: ${args.availableRules().collect { it.name() }}
-                  | - Rules that will run: ${args.rulesThatWillRun().collect { it.name() }}
+                """Scalafix rules:
+                  | - Available: ${args.availableRules().collect { it.name() }}
+                  | - That will run: ${args.rulesThatWillRun().collect { it.name() }}
                   |""".stripMargin())
 
         if (!args.rulesThatWillRun().empty) {
@@ -84,27 +95,6 @@ class ScalafixTask extends SourceTask {
         } else {
             logger.warn("No Scalafix rules to run")
         }
-    }
-
-    private List<String> getScalacOptions() {
-        getCompileTask().scalaCompileOptions.additionalParameters ?: []
-    }
-
-    private String getScalaVersion() {
-        def scalaRuntime = project.extensions.findByType(ScalaRuntime.class)
-        def scalaJar = scalaRuntime.findScalaJar(getCompileTask().classpath, "library")
-        scalaRuntime.getScalaVersion(scalaJar)
-    }
-
-    private ScalaCompile getCompileTask() {
-        project.tasks.withType(ScalaCompile).first()
-    }
-
-    private List<Path> getProjectClasspath() {
-        def classesDirs = project.sourceSets.collect { SourceSet ss ->
-            ss.output.classesDirs.toList()
-        }.flatten()
-        classesDirs.collect { it.toPath() }
     }
 
     private static URLClassLoader classloaderFrom(Configuration configuration, ClassLoader parent) {

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
@@ -1,7 +1,6 @@
 package io.github.cosmicsilence.scalafix
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
@@ -35,7 +34,7 @@ class ScalafixTask extends SourceTask {
 
     @Input
     @Optional
-    FileCollection classpath
+    List<File> classpath
 
     @Input
     File sourceRoot
@@ -49,7 +48,7 @@ class ScalafixTask extends SourceTask {
     private void processSources() {
         def sourcePaths = source.collect { it.toPath() }
         def configPath = java.util.Optional.ofNullable(configFile.getOrNull()).map { it.asFile.toPath() }
-        def projectClasspath = classpath.collect { it.toPath() }
+        def projectClasspath = (classpath ?: []).collect { it.toPath() }
         def cliDependency = project.dependencies.create(BuildInfo.scalafixCliArtifact)
         def cliClasspath = project.configurations.detachedConfiguration(cliDependency)
         def customRulesClasspath = project.configurations.getByName(ScalafixPlugin.CUSTOM_RULES_CONFIGURATION)

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -110,6 +110,30 @@ sourceSets {
         buildResult.output.contains(':checkScalafixIntegTest SKIPPED')
     }
 
+    def 'all tasks should be grouped'() {
+        given:
+        buildFile.append '''
+sourceSets {
+    foo { }
+}'''
+
+        when:
+        BuildResult buildResult = runGradleTask('tasks', [])
+
+        then:
+        buildResult.output.contains(
+                """Scalafix tasks
+                  |--------------
+                  |checkScalafix - Fails if running Scalafix produces a diff or a linter error message. Won't write to files
+                  |checkScalafixFoo - Fails if running Scalafix produces a diff or a linter error message. Won't write to files in 'foo'
+                  |checkScalafixMain - Fails if running Scalafix produces a diff or a linter error message. Won't write to files in 'main'
+                  |checkScalafixTest - Fails if running Scalafix produces a diff or a linter error message. Won't write to files in 'test'
+                  |scalafix - Runs Scalafix on Scala sources
+                  |scalafixFoo - Runs Scalafix on Scala sources in 'foo'
+                  |scalafixMain - Runs Scalafix on Scala sources in 'main'
+                  |scalafixTest - Runs Scalafix on Scala sources in 'test'""".stripMargin())
+    }
+
     BuildResult runGradleTask(String task, List<String> arguments) {
         arguments.add(task)
         return GradleRunner.create()

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -31,7 +31,7 @@ repositories {
         settingsFile.write "rootProject.name = 'hello-world'"
     }
 
-    def 'checkScalafixMain task runs compileScala by default'() {
+    def 'scalafixMain task runs compileScala by default'() {
         when:
         BuildResult buildResult = runGradleTask('scalafix', ['-m'])
 
@@ -42,7 +42,7 @@ repositories {
         buildResult.output.contains(':scalafixTest SKIPPED')
     }
 
-    def 'checkScalafixMain task runs compileScala when autoConfigureSemanticdb is enabled in the scalafix extension'() {
+    def 'scalafixMain task runs compileScala when autoConfigureSemanticdb is enabled in the scalafix extension'() {
         given:
         buildFile.append '''
 scalafix { autoConfigureSemanticdb = true }'''
@@ -57,7 +57,7 @@ scalafix { autoConfigureSemanticdb = true }'''
         buildResult.output.contains(':scalafixTest SKIPPED')
     }
 
-    def 'checkScalafixMain task does not run compileScala when autoConfigureSemanticdb is disabled in the scalafix extension'() {
+    def 'scalafixMain task does not run compileScala when autoConfigureSemanticdb is disabled in the scalafix extension'() {
         given:
         buildFile.append '''
 scalafix { autoConfigureSemanticdb = false }'''
@@ -70,6 +70,47 @@ scalafix { autoConfigureSemanticdb = false }'''
         !buildResult.output.contains(':compileTestScala SKIPPED')
         buildResult.output.contains(':scalafixMain SKIPPED')
         buildResult.output.contains(':scalafixTest SKIPPED')
+    }
+
+    def 'checkScalafix task runs compileScala by default'() {
+        when:
+        BuildResult buildResult = runGradleTask('checkScalafix', ['-m'])
+
+        then:
+        buildResult.output.contains(':compileScala SKIPPED')
+        buildResult.output.contains(':compileTestScala SKIPPED')
+        buildResult.output.contains(':checkScalafixMain SKIPPED')
+        buildResult.output.contains(':checkScalafixTest SKIPPED')
+    }
+
+    def 'checkScalafix task runs compileScala when autoConfigureSemanticdb is enabled in the scalafix extension'() {
+        given:
+        buildFile.append '''
+scalafix { autoConfigureSemanticdb = true }'''
+
+        when:
+        BuildResult buildResult = runGradleTask('checkScalafix', ['-m'])
+
+        then:
+        buildResult.output.contains(':compileScala SKIPPED')
+        buildResult.output.contains(':compileTestScala SKIPPED')
+        buildResult.output.contains(':checkScalafixMain SKIPPED')
+        buildResult.output.contains(':checkScalafixTest SKIPPED')
+    }
+
+    def 'checkScalafix task does not run compileScala when autoConfigureSemanticdb is disabled in the scalafix extension'() {
+        given:
+        buildFile.append '''
+scalafix { autoConfigureSemanticdb = false }'''
+
+        when:
+        BuildResult buildResult = runGradleTask('checkScalafix', ['-m'])
+
+        then:
+        !buildResult.output.contains(':compileScala SKIPPED')
+        !buildResult.output.contains(':compileTestScala SKIPPED')
+        buildResult.output.contains(':checkScalafixMain SKIPPED')
+        buildResult.output.contains(':checkScalafixTest SKIPPED')
     }
 
     def 'scalafix<SourceSet> task is created and runs compile<SourceSet>Scala by default when additional source set exists in the build script'() {

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -132,11 +132,11 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/main/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions == DEFAULT_COMPILER_OPTS
         task.scalaVersion == SCALA_VERSION
         task.rules.get().containsAll(['Foo', 'Bar'])
@@ -160,11 +160,11 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/main/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.contains("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
         task.compileOptions.find { it.startsWith("-Xplugin:") }
         task.scalaVersion == SCALA_VERSION
@@ -189,11 +189,11 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/test/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/test/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions == DEFAULT_COMPILER_OPTS
         task.scalaVersion == SCALA_VERSION
         task.rules.get().containsAll(['Foo', 'Bar'])
@@ -217,11 +217,11 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/test/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/test/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
         task.compileOptions.find { it.startsWith("-Xplugin:") }
         task.scalaVersion == SCALA_VERSION
@@ -260,11 +260,11 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/main/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions == DEFAULT_COMPILER_OPTS
         task.scalaVersion == SCALA_VERSION
         task.rules.get().containsAll(['Foo', 'Bar'])
@@ -288,11 +288,11 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/main/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
         task.compileOptions.find { it.startsWith("-Xplugin:") }
         task.scalaVersion == SCALA_VERSION
@@ -317,11 +317,11 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/test/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/test/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions == DEFAULT_COMPILER_OPTS
         task.scalaVersion == SCALA_VERSION
         task.rules.get().containsAll(['Foo', 'Bar'])
@@ -345,11 +345,11 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/test/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/test/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
         task.compileOptions.find { it.startsWith("-Xplugin:") }
         task.scalaVersion == SCALA_VERSION
@@ -376,13 +376,13 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/foo/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/foo/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/foo")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/foo")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/foo"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/foo"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions == DEFAULT_COMPILER_OPTS
         task.scalaVersion == SCALA_VERSION
         task.rules.get().containsAll(['Foo', 'Bar'])
@@ -408,13 +408,13 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/bar/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/bar/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/bar")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/bar")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/bar"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/bar"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
         task.compileOptions.find { it.startsWith("-Xplugin:") }
         task.scalaVersion == SCALA_VERSION
@@ -441,13 +441,13 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/foo/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/foo/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/foo")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/foo")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/foo"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/foo"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions == DEFAULT_COMPILER_OPTS
         task.scalaVersion == SCALA_VERSION
         task.rules.get().containsAll(['Foo', 'Bar'])
@@ -473,13 +473,13 @@ class ScalafixPluginTest extends Specification {
                 new File(scalaProject.projectDir, "/src/bar/scala/Dog.scala"),
                 new File(scalaProject.projectDir, "/src/bar/scala/Duck.scala")
         ].toSet()
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/bar")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
-        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/bar")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
-        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
-        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/bar"))
+        task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/bar"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/main"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/scala/test"))
+        !task.classpath.contains(new File(scalaProject.projectDir, "/build/classes/java/test"))
+        task.classpath.find { it.path.endsWith("scala-library-${SCALA_VERSION}.jar") }
         task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
         task.compileOptions.find { it.startsWith("-Xplugin:") }
         task.scalaVersion == SCALA_VERSION

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -3,45 +3,43 @@ package io.github.cosmicsilence.scalafix
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.tasks.scala.ScalaCompile
 import org.gradle.testfixtures.ProjectBuilder
 import scalafix.interfaces.ScalafixMainMode
 import spock.lang.Specification
 
 class ScalafixPluginTest extends Specification {
 
-    private Project project
-    private File scalafixConf
+    private static final String SCALA_VERSION = "2.12.8"
+    private static final List<String> DEFAULT_COMPILER_OPTS = ["-Ywarn-unused" ]
+
+    private Project scalaProject
 
     def setup() {
-        project = ProjectBuilder.builder().build()
-        project.repositories {
-            mavenCentral()
-        }
-
-        scalafixConf = new File(project.projectDir, 'scalafix.conf')
-        scalafixConf.write 'rules = [Foo, Bar]'
+        scalaProject = buildScalaProject()
     }
 
     def 'The plugin adds the scalafix configuration, tasks and extension to the project'() {
         given:
-        applyScalafixPlugin(project)
+        applyScalafixPlugin(scalaProject)
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        project.tasks.scalafix
-        project.tasks.scalafixMain
-        project.tasks.scalafixTest
-        project.tasks.checkScalafix
-        project.tasks.checkScalafixMain
-        project.tasks.checkScalafixTest
-        project.extensions.scalafix
-        project.configurations.scalafix
+        scalaProject.tasks.scalafix
+        scalaProject.tasks.scalafixMain
+        scalaProject.tasks.scalafixTest
+        scalaProject.tasks.checkScalafix
+        scalaProject.tasks.checkScalafixMain
+        scalaProject.tasks.checkScalafixTest
+        scalaProject.extensions.scalafix
+        scalaProject.configurations.scalafix
     }
 
     def 'The plugin throws an exception if the scala plugin has not been applied to the project'() {
         given:
+        def project = ProjectBuilder.builder().build()
         project.pluginManager.apply 'io.github.cosmicsilence.scalafix'
 
         when:
@@ -53,8 +51,10 @@ class ScalafixPluginTest extends Specification {
 
     def 'The plugin should not throw any exception if the scala plugin is applied after it'() {
         given:
+        def project = ProjectBuilder.builder().build()
         project.pluginManager.apply 'io.github.cosmicsilence.scalafix'
         project.pluginManager.apply 'scala'
+        project.scalafix.autoConfigureSemanticdb = false
 
         when:
         project.evaluate()
@@ -65,351 +65,597 @@ class ScalafixPluginTest extends Specification {
 
     def 'The plugin adds the semanticdb plugin config to the compiler options when autoConfigureSemanticdb is set to true'() {
         given:
-        applyScalafixPlugin(project, true)
+        applyScalafixPlugin(scalaProject, true)
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        def compileScalaParameters = project.tasks.getByName('compileScala').scalaCompileOptions.additionalParameters
-        compileScalaParameters.contains('-Yrangepos')
-        compileScalaParameters.find { it.contains('-P:semanticdb:sourceroot:') }
+        def compileScalaParameters = scalaProject.tasks.getByName('compileScala').scalaCompileOptions.additionalParameters
+        compileScalaParameters.containsAll(DEFAULT_COMPILER_OPTS + ['-Yrangepos', "-P:semanticdb:sourceroot:${scalaProject.projectDir}".toString()])
         compileScalaParameters.find {
-            it.contains('-Xplugin:') && it.contains('semanticdb-scalac_2.12.10-4.3.0.jar') && it.contains('scala-library-2.12.10.jar')
+            it.startsWith('-Xplugin:') &&
+                    it.contains("semanticdb-scalac_${BuildInfo.scala212Version}-${BuildInfo.scalametaVersion}.jar") &&
+                    it.contains("scala-library-${BuildInfo.scala212Version}.jar")
         }
 
-        def compileTestScalaParameters = project.tasks.getByName('compileTestScala').scalaCompileOptions.additionalParameters
-        compileTestScalaParameters.contains('-Yrangepos')
-        compileTestScalaParameters.find { it.contains('-P:semanticdb:sourceroot:') }
+        def compileTestScalaParameters = scalaProject.tasks.getByName('compileTestScala').scalaCompileOptions.additionalParameters
+        compileTestScalaParameters.containsAll(DEFAULT_COMPILER_OPTS + ['-Yrangepos', "-P:semanticdb:sourceroot:${scalaProject.projectDir}".toString()])
         compileTestScalaParameters.find {
-            it.contains('-Xplugin:') && it.contains('semanticdb-scalac_2.12.10-4.3.0.jar') && it.contains('scala-library-2.12.10.jar')
+            it.startsWith('-Xplugin:') &&
+                    it.contains("semanticdb-scalac_${BuildInfo.scala212Version}-${BuildInfo.scalametaVersion}.jar") &&
+                    it.contains("scala-library-${BuildInfo.scala212Version}.jar")
         }
     }
 
     def 'Semanticdb configuration is not added if autoConfigureSemanticdb is set to false'() {
         given:
-        applyScalafixPlugin(project, false)
+        applyScalafixPlugin(scalaProject, false)
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        !project.tasks.getByName('compileScala').scalaCompileOptions.additionalParameters
-        !project.tasks.getByName('compileTestScala').scalaCompileOptions.additionalParameters
+        scalaProject.tasks.getByName('compileScala').scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
+        scalaProject.tasks.getByName('compileTestScala').scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
     }
 
     def 'checkScalafix task configuration validation'() {
         given:
-        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject)
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        Task task = project.tasks.getByName('checkScalafix')
+        Task task = scalaProject.tasks.getByName('checkScalafix')
         task.dependsOn.find { it.name == 'checkScalafixMain' }
         task.dependsOn.find { it.name == 'checkScalafixTest' }
-        project.tasks.getByName('check').dependsOn.find { it.name == 'checkScalafix' }
+        scalaProject.tasks.getByName('check').dependsOn.find { it.name == 'checkScalafix' }
     }
 
     def 'checkScalafixMain task configuration validation'() {
         given:
-        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject, false, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixMain')
         task.dependsOn.isEmpty()
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
         task.mode == ScalafixMainMode.CHECK
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/main/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/main/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions == DEFAULT_COMPILER_OPTS
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'checkScalafixMain task configuration validation when autoConfigureSemanticDb is enabled'() {
         given:
-        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject, true, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixMain')
         task.dependsOn.find{ it.name == 'compileScala' }
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
         task.mode == ScalafixMainMode.CHECK
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/main/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/main/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
+        task.compileOptions.find { it.startsWith("-Xplugin:") }
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'checkScalafixTest task configuration validation'() {
         given:
-        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject, false, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('checkScalafixTest')
+        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixTest')
         task.dependsOn.isEmpty()
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
         task.mode == ScalafixMainMode.CHECK
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/test/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/test/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/test/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions == DEFAULT_COMPILER_OPTS
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'checkScalafixTest task configuration validation when autoConfigureSemanticDb is enabled'() {
         given:
-        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject, true, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('checkScalafixTest')
+        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixTest')
         task.dependsOn.find{ it.name == 'compileTestScala' }
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
         task.mode == ScalafixMainMode.CHECK
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/test/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/test/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/test/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
+        task.compileOptions.find { it.startsWith("-Xplugin:") }
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'scalafix task configuration validation'() {
         given:
-        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject)
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        Task task = project.tasks.getByName('scalafix')
+        Task task = scalaProject.tasks.getByName('scalafix')
         task.dependsOn.find { it.name == 'scalafixMain' }
         task.dependsOn.find { it.name == 'scalafixTest' }
-        !project.tasks.getByName('check').dependsOn.find { it.name == 'scalafix' }
+        !scalaProject.tasks.getByName('check').dependsOn.find { it.name == 'scalafix' }
     }
 
     def 'scalafixMain task configuration validation'() {
         given:
-        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject, false, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('scalafixMain')
+        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
         task.dependsOn.isEmpty()
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
         task.mode == ScalafixMainMode.IN_PLACE
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/main/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/main/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions == DEFAULT_COMPILER_OPTS
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'scalafixMain task configuration validation when autoConfigureSemanticDb is enabled'() {
         given:
-        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject, true, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('scalafixMain')
+        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
         task.dependsOn.find { it.name == 'compileScala' }
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
         task.mode == ScalafixMainMode.IN_PLACE
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/main/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/main/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
+        task.compileOptions.find { it.startsWith("-Xplugin:") }
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'scalafixTest task configuration validation'() {
         given:
-        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject, false, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('scalafixTest')
+        ScalafixTask task = scalaProject.tasks.getByName('scalafixTest')
         task.dependsOn.isEmpty()
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
         task.mode == ScalafixMainMode.IN_PLACE
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/test/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/test/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/test/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions == DEFAULT_COMPILER_OPTS
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'scalafixTest task configuration validation when autoConfigureSemanticDb is enabled'() {
         given:
-        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
+        applyScalafixPlugin(scalaProject, true, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('scalafixTest')
+        ScalafixTask task = scalaProject.tasks.getByName('scalafixTest')
         task.dependsOn.find { it.name == 'compileTestScala' }
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
         task.mode == ScalafixMainMode.IN_PLACE
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/test/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/test/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/test/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
+        task.compileOptions.find { it.startsWith("-Xplugin:") }
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'scalafix<SourceSet> task configuration validation when additional source set is present'() {
         given:
-        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
-        project.with {
-            sourceSets {
-                foo { }
-            }
-        }
+        def scalaProject = buildScalaProject(null, ["foo"])
+        applyScalafixPlugin(scalaProject, false, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('scalafixFoo')
+        ScalafixTask task = scalaProject.tasks.getByName('scalafixFoo')
         task.dependsOn.isEmpty()
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
-        project.tasks.getByName('scalafix').dependsOn(task)
+        scalaProject.tasks.getByName('scalafix').dependsOn(task)
+        task.mode == ScalafixMainMode.IN_PLACE
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/foo/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/foo/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/foo/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/foo")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/foo")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions == DEFAULT_COMPILER_OPTS
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'scalafix<SourceSet> task configuration validation when additional source set is present and autoConfigureSemanticDb is enabled'() {
         given:
-        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
-        project.with {
-            sourceSets {
-                bar { }
-            }
-        }
+        def scalaProject = buildScalaProject(null, ["bar"])
+        applyScalafixPlugin(scalaProject, true, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('scalafixBar')
+        ScalafixTask task = scalaProject.tasks.getByName('scalafixBar')
         task.dependsOn.find { it.name == 'compileBarScala' }
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
-        project.tasks.getByName('scalafix').dependsOn(task)
+        scalaProject.tasks.getByName('scalafix').dependsOn(task)
+        task.mode == ScalafixMainMode.IN_PLACE
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/bar/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/bar/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/bar/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/bar")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/bar")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
+        task.compileOptions.find { it.startsWith("-Xplugin:") }
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'checkScalafix<SourceSet> task configuration validation when additional source set is present'() {
         given:
-        applyScalafixPlugin(project, false, 'Foo,Bar', project.file('.scalafix.conf'))
-        project.with {
-            sourceSets {
-                foo { }
-            }
-        }
+        def scalaProject = buildScalaProject(null, ["foo"])
+        applyScalafixPlugin(scalaProject, false, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('checkScalafixFoo')
+        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixFoo')
         task.dependsOn.isEmpty()
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
-        project.tasks.getByName('checkScalafix').dependsOn(task)
+        scalaProject.tasks.getByName('checkScalafix').dependsOn(task)
+        task.mode == ScalafixMainMode.CHECK
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/foo/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/foo/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/foo/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/foo")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/foo")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions == DEFAULT_COMPILER_OPTS
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
     def 'checkScalafix<SourceSet> task configuration validation when additional source set is present and autoConfigureSemanticDb is enabled'() {
         given:
-        applyScalafixPlugin(project, true, 'Foo,Bar', project.file('.scalafix.conf'))
-        project.with {
-            sourceSets {
-                bar { }
-            }
-        }
+        def scalaProject = buildScalaProject(null, ["bar"])
+        applyScalafixPlugin(scalaProject, true, 'Foo,Bar', scalaProject.file('.custom.conf'))
 
         when:
-        project.evaluate()
+        scalaProject.evaluate()
 
         then:
-        ScalafixTask task = project.tasks.getByName('checkScalafixBar')
+        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixBar')
         task.dependsOn.find { it.name == 'compileBarScala' }
-        task.configFile.get().asFile.path == "${project.projectDir}/.scalafix.conf"
-        task.rules.get().contains('Foo')
-        task.rules.get().contains('Bar')
-        project.tasks.getByName('checkScalafix').dependsOn(task)
+        scalaProject.tasks.getByName('checkScalafix').dependsOn(task)
+        task.mode == ScalafixMainMode.CHECK
+        task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
+        task.sourceRoot == scalaProject.projectDir
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/bar/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/bar/scala/Dog.scala"),
+                new File(scalaProject.projectDir, "/src/bar/scala/Duck.scala")
+        ].toSet()
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/bar")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/scala/test")
+        task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/bar")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/main")
+        !task.classpath.asPath.contains("${scalaProject.projectDir}/build/classes/java/test")
+        task.classpath.asPath.contains("scala-library-${SCALA_VERSION}.jar")
+        task.compileOptions.containsAll(DEFAULT_COMPILER_OPTS + "-Yrangepos")
+        task.compileOptions.find { it.startsWith("-Xplugin:") }
+        task.scalaVersion == SCALA_VERSION
+        task.rules.get().containsAll(['Foo', 'Bar'])
     }
 
-    def 'scalafix uses the .scalafix config file provided via extension'() {
+    def 'scalafix uses the config file provided via extension'() {
         given:
-        Project subproject = ProjectBuilder.builder().withName('the-subproject')
-                .withParent(project).build()
-        subproject.projectDir.mkdir()
-        File subprojectScalafixConf = new File(subproject.projectDir, '.scalafix.conf')
-        subprojectScalafixConf.write 'rules = [Foo, Bar]'
-        File extensionScalafixConf = new File(subproject.projectDir, '.test-scalafix.conf')
-        extensionScalafixConf.write 'rules = [Foo, Bar]'
-        applyScalafixPlugin(subproject, false, '', extensionScalafixConf)
+        Project rootProject = ProjectBuilder.builder().withName("root").build()
+        File rootProjectConfig = new File(rootProject.projectDir, '.scalafix.conf')
+        rootProjectConfig.write 'rules = [Foo, Bar]'
+
+        Project subProject = buildScalaProject(rootProject)
+        File subProjectConfig = new File(subProject.projectDir, '.scalafix.conf')
+        subProjectConfig.write 'rules = [Foo, Bar]'
+
+        File extensionConfig = new File(subProject.projectDir, '.custom.conf')
+        extensionConfig.write 'rules = [Foo, Bar]'
+
+        applyScalafixPlugin(subProject, false, '', extensionConfig)
 
         when:
-        subproject.evaluate()
+        subProject.evaluate()
 
         then:
-        ScalafixTask task = subproject.tasks.getByName('checkScalafixMain')
-        task.configFile.get().asFile.path == "${subproject.projectDir}/.test-scalafix.conf"
+        ScalafixTask task = subProject.tasks.getByName('checkScalafixMain')
+        task.configFile.get().asFile.path == extensionConfig.path
     }
 
-    def 'scalafix uses the .scalafix config file from the subproject if it has not been provided via extension'() {
+    def 'scalafix uses the config file from the subproject if it has not been provided via extension'() {
         given:
-        Project subproject = ProjectBuilder.builder().withName('the-subproject')
-                .withParent(project).build()
-        subproject.projectDir.mkdir()
-        File subprojectScalafixConf = new File(subproject.projectDir, '.scalafix.conf')
-        subprojectScalafixConf.write 'rules = [Foo, Bar]'
-        applyScalafixPlugin(subproject, false, '', null)
+        Project rootProject = ProjectBuilder.builder().withName("root").build()
+        File rootProjectConfig = new File(rootProject.projectDir, '.scalafix.conf')
+        rootProjectConfig.write 'rules = [Foo, Bar]'
+
+        Project subProject = buildScalaProject(rootProject)
+        File subProjectConfig = new File(subProject.projectDir, '.scalafix.conf')
+        subProjectConfig.write 'rules = [Foo, Bar]'
+
+        applyScalafixPlugin(subProject)
 
         when:
-        subproject.evaluate()
+        subProject.evaluate()
 
         then:
-        ScalafixTask task = subproject.tasks.getByName('checkScalafixMain')
-        task.configFile.get().asFile.path == "${subproject.projectDir}/.scalafix.conf"
+        ScalafixTask task = subProject.tasks.getByName('checkScalafixMain')
+        task.configFile.get().asFile.path == subProjectConfig.path
     }
 
-    def 'scalafix uses the .scalafix config file from the root project as the file is not present in the subproject and\
- it is not specified in the extension'() {
+    def 'scalafix uses the config file from the root project as the file is not present in the subproject and it is not specified in the extension'() {
         given:
-        Project subproject = ProjectBuilder.builder().withParent(project).withName('the-subproject').build()
-        scalafixConf.delete()
-        applyScalafixPlugin(subproject, false, '', null)
+        Project rootProject = ProjectBuilder.builder().withName("root").build()
+        File rootProjectConfig = new File(rootProject.projectDir, '.scalafix.conf')
+        rootProjectConfig.write 'rules = [Foo, Bar]'
+
+        Project subProject = buildScalaProject(rootProject)
+        applyScalafixPlugin(subProject)
 
         when:
-        subproject.evaluate()
+        subProject.evaluate()
 
         then:
-        ScalafixTask task = subproject.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = subProject.tasks.getByName('checkScalafixMain')
+        task.configFile.get().asFile.path == rootProjectConfig.path
     }
 
-    def 'scalafix does not use any scalafix.conf file as it is not provided'() {
+    def 'scalafix does not use any config file as it is not provided'() {
         given:
-        Project subproject = ProjectBuilder.builder().withParent(project).withName('the-subproject').build()
-        scalafixConf.delete()
-        applyScalafixPlugin(subproject, false, '', null)
+        Project rootProject = ProjectBuilder.builder().withName("root").build()
+        Project subProject = buildScalaProject(rootProject)
+        applyScalafixPlugin(subProject)
 
         when:
-        subproject.evaluate()
+        subProject.evaluate()
 
         then:
-        ScalafixTask task = subproject.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = subProject.tasks.getByName('checkScalafixMain')
         !task.configFile.get()
     }
 
-    private applyScalafixPlugin(Project project, Boolean autoConfigureSemanticDb = false,
-                                String rules = '', File configFile = project.file('.scalafix.conf')) {
+    def 'scalafix should only select sources matching include filter'() {
+        given:
+        applyScalafixPlugin(scalaProject)
+        scalaProject.scalafix.includes = [ "**/Cat.scala", "**/Duck.scala" ]
+
+        when:
+        scalaProject.evaluate()
+
+        then:
+        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
+        task.source.files == [
+                new File(scalaProject.projectDir, "/src/main/scala/Cat.scala"),
+                new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
+        ].toSet()
+    }
+
+    def 'scalafix should not select sources matching exclude filter'() {
+        given:
+        applyScalafixPlugin(scalaProject)
+        scalaProject.scalafix.excludes = [ "**/Cat.scala", "**/Duck.scala" ]
+
+        when:
+        scalaProject.evaluate()
+
+        then:
+        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
+        task.source.asPath == "${scalaProject.projectDir}/src/main/scala/Dog.scala"
+    }
+
+    def 'scalafix should select sources matching include filter and not matching exclude filter'() {
+        given:
+        applyScalafixPlugin(scalaProject)
+        scalaProject.scalafix.includes = [ "**/D*.scala" ]
+        scalaProject.scalafix.excludes = [ "**/*g.scala" ]
+
+        when:
+        scalaProject.evaluate()
+
+        then:
+        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
+        task.source.asPath == "${scalaProject.projectDir}/src/main/scala/Duck.scala"
+    }
+
+    private applyScalafixPlugin(Project project,
+                                Boolean autoConfigureSemanticDb = false,
+                                String rules = '',
+                                File configFile = null) {
         project.with {
-            apply plugin: 'scala'
             apply plugin: 'io.github.cosmicsilence.scalafix'
+
             scalafix.autoConfigureSemanticdb = autoConfigureSemanticDb
             scalafix.configFile = configFile
             ext.'scalafix.rules' = rules
         }
+    }
+
+    private Project buildScalaProject(Project parent = null, List<String> extraSourceSets = []) {
+        def project = ProjectBuilder.builder().withParent(parent).build()
+        def standardSourceSets = ["main", "test"]
+
+        (standardSourceSets + extraSourceSets).forEach {
+            def folder = new File(project.projectDir, "/src/$it/scala/")
+            folder.mkdirs()
+            ["Dog", "Cat", "Duck"].forEach {
+                def sourceFile = new File(folder, "${it}.scala")
+                sourceFile.write "class $it"
+            }
+        }
+
+        project.with {
+            apply plugin: 'scala'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                compile "org.scala-lang:scala-library:$SCALA_VERSION"
+            }
+
+            sourceSets {
+                extraSourceSets.collect {
+                    "${it}" {
+                        scala {
+                            srcDir "src/$it/scala"
+                        }
+                        compileClasspath += main.compileClasspath
+                    }
+                }
+            }
+
+            tasks.withType(ScalaCompile) {
+                scalaCompileOptions.additionalParameters = DEFAULT_COMPILER_OPTS
+            }
+        }
+
+        return project
     }
 }


### PR DESCRIPTION
Turning more settings that used to be resolved inside the task class into task inputs. This allows the  Scala version and compile options to be obtained from the correct source set that the task is applied.

Also, fixed NPE thrown when plugin attempted to obtain the Scala version but the source set did not have any scala-library dependency.