### PR TITLE
Use getOrNull to obtain the config file from task input property

### DIFF
--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
@@ -36,7 +36,7 @@ class ScalafixTask extends SourceTask {
 
     private void processSources() {
         def sourcePaths = source.collect { it.toPath() }
-        def config = java.util.Optional.ofNullable(configFile.get()).map { it.asFile.toPath() }
+        def config = java.util.Optional.ofNullable(configFile.getOrNull()).map { it.asFile.toPath() }
         def cliDependency = project.dependencies.create(BuildInfo.scalafixCliArtifact)
         def cliClasspath = project.configurations.detachedConfiguration(cliDependency)
         def customRulesClasspath = project.configurations.getByName(ScalafixPlugin.CUSTOM_RULES_CONFIGURATION)


### PR DESCRIPTION
The last commit introduced a bug when no scalafix config file is informed nor it exists at the standard locations:

```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':scalafixMain'.
Caused by: java.lang.IllegalStateException: No value has been specified for this provider.
	at org.gradle.api.internal.provider.Providers$1.get(Providers.java:32)
	at org.gradle.api.internal.provider.DefaultProperty.get(DefaultProperty.java:157)
	at org.gradle.api.provider.Provider$get.call(Unknown Source)
	at io.github.cosmicsilence.scalafix.ScalafixTask.processSources(ScalafixTask.groovy:39)
```

Issue reported by @tomnis