### PR TITLE
Add option in the extension to allow source sets to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,12 @@ tasks.withType(ScalaCompile) {
 
 The following Gradle tasks are created when the Scalafix plugin is applied to a project:
 
-* *`scalafix`* - runs rewrite and linter rules for all source sets. Rewrite rules may modify files in-place whereas linter
-rules will print diagnostics to Gradle's output. 
-* *`scalafix<SourceSet>`* - same as above, but for a single source set (e.g. *`scalafixMain`*, *`scalafixTest`*, *`scalafixFoo`*).
-* *`checkScalafix`* - checks that source files of all source sets are compliant to rewrite and linter rules. Any violation
-is printed to Gradle's output and the task exits with an error. No source file gets modified. This task is automatically
-triggered by the `check` task.
-* *`checkScalafix<SourceSet>`* - same as above, but for a single source set (e.g. *`checkScalafixMain`*, *`checkScalafixTest`*, *`checkScalafixBar`*).
-
+| Name                       | Description          |
+|:---------------------------|----------------------|
+|*`scalafix`*                |Runs rewrite and linter rules for all source sets. Rewrite rules may modify files in-place whereas linter rules will print diagnostics to Gradle's output.|
+|*`scalafix<SourceSet>`*     |Same as above, but for a single source set (e.g. *`scalafixMain`*, *`scalafixTest`*, *`scalafixFoo`*).|
+|*`checkScalafix`*           |Checks that source files of all source sets are compliant to rewrite and linter rules. Any violation is printed to Gradle's output and the task exits with an error. No source file gets modified. This task is automatically triggered by the `check` task.|
+|*`checkScalafix<SourceSet>`*|Same as above, but for a single source set (e.g. *`checkScalafixMain`*, *`checkScalafixTest`*, *`checkScalafixBar`*).|
 
 >**NOTE:** If the **SemanticDB** Scala compiler plugin is enabled (see the [extension](#extension) section for more details),
 any of these tasks will trigger partial or complete compilation of Scala source files.

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ The following Gradle tasks are created when the Scalafix plugin is applied to a 
 
 * *`scalafix`* - runs rewrite and linter rules for all source sets. Rewrite rules may modify files in-place whereas linter
 rules will print diagnostics to Gradle's output. 
-* *`scalafix<SourceSet>`* - same as above, but for a single source set (e.g. *`scalafixMain`*, *`scalafixTest`*).
-* *`checkScalafix`* - check that source files of all source sets are compliant to rewrite and linter rules. Any violation
+* *`scalafix<SourceSet>`* - same as above, but for a single source set (e.g. *`scalafixMain`*, *`scalafixTest`*, *`scalafixFoo`*).
+* *`checkScalafix`* - checks that source files of all source sets are compliant to rewrite and linter rules. Any violation
 is printed to Gradle's output and the task exits with an error. No source file gets modified. This task is automatically
 triggered by the `check` task.
-* *`checkScalafix<SourceSet>`* - same as above, but for a single source set (e.g. *`checkScalafixMain`*, *`checkScalafixTest`*).
+* *`checkScalafix<SourceSet>`* - same as above, but for a single source set (e.g. *`checkScalafixMain`*, *`checkScalafixTest`*, *`checkScalafixBar`*).
 
 
 >**NOTE:** If the **SemanticDB** Scala compiler plugin is enabled (see the [extension](#extension) section for more details),
@@ -137,6 +137,7 @@ The plugin defines an extension with the namespace `scalafix`. The following pro
 |`configFile`              |`String`              |\<empty\>      |Same as above. |
 |`includes`                |`SetProperty<String>` |\<empty\>      |[Ant-like pattern](https://ant.apache.org/manual/dirtasks.html) to filter what Scala source files should be processed by Scalafix. By default all files are included. |
 |`excludes`                |`SetProperty<String>` |\<empty\>      |[Ant-like pattern](https://ant.apache.org/manual/dirtasks.html) to exclude Scala source files from being processed by Scalafix. By default no files are excluded. |
+|`ignoreSourceSets`        |`SetProperty<String>` |\<empty\>      |Name of source sets to which the Scalafix plugin should not be applied (by default this plugin is applied to all source sets defined in the project). This option can be used (e.g.) to ignore source sets that point to the same source files of other source sets (which would cause them to be processed twice).|
 |`autoConfigureSemanticdb` |`Boolean`             |`true`         |Used to indicate whether the Scalafix plugin should auto-configure the SemanticDB compiler plugin. This is mandatory to be able to run Scalafix's semantic rules. If set to `true` (default), the Scalafix Gradle tasks will cause the Scala compiler to kick in whenever they are run. If your project only uses syntactic rules, then it's highly recommended that this property is set to `false` as the SemanticDB compiler plugin may cause a substantial slow down in your build. The Scalafix plugin auto-configures only the necessary parameters for SemanticDB (`-Xplugin:`, `-P:semanticdb:sourceroot:` and `-Yrangepos`). If you need to use more advanced settings, please consult [this section](https://scalacenter.github.io/scalafix/docs/users/installation.html#exclude-files-from-semanticdb) on the Scalafix website as well as the [SemanticDB docs](https://scalameta.org/docs/semanticdb/guide.html#scalac-compiler-plugin). Any additional SemanticDB settings can be informed through the Gradle's `ScalaCompile` task as shown earlier. |
 
 
@@ -146,6 +147,7 @@ scalafix {
     configFile = file("config/myscalafix.conf")
     includes = ["**/com/**/*.scala"]
     excludes = ["**/generated/**"]
+    ignoreSourceSets = ["scoverage"]
     autoConfigureSemanticdb = false
 }
 ```

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
@@ -31,6 +31,11 @@ class ScalafixExtension {
     final SetProperty<String> excludes
 
     /**
+     * Name of source sets to which the Scalafix plugin should not be applied.
+     */
+    final SetProperty<String> ignoreSourceSets
+
+    /**
      * Auto configures the SemanticDB Scala compiler. This is required to run
      * semantic rules.
      */
@@ -46,6 +51,7 @@ class ScalafixExtension {
                 locateConfigFile(project) ?: locateConfigFile(project.rootProject))
         includes = project.objects.setProperty(String)
         excludes = project.objects.setProperty(String)
+        ignoreSourceSets = project.objects.setProperty(String)
     }
 
     private RegularFile locateConfigFile(Project project) {

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -55,8 +55,10 @@ class ScalafixPlugin implements Plugin<Project> {
         project.tasks.check.dependsOn checkTask
 
         project.sourceSets.each { SourceSet sourceSet ->
-            configureTaskForSourceSet(sourceSet, IN_PLACE, fixTask, project, extension)
-            configureTaskForSourceSet(sourceSet, CHECK, checkTask, project, extension)
+            if (!extension.ignoreSourceSets.get().contains(sourceSet.name)) {
+                configureTaskForSourceSet(sourceSet, IN_PLACE, fixTask, project, extension)
+                configureTaskForSourceSet(sourceSet, CHECK, checkTask, project, extension)
+            }
         }
     }
 

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -603,6 +603,24 @@ class ScalafixPluginTest extends Specification {
         task.source.asPath == "${scalaProject.projectDir}/src/main/scala/Duck.scala"
     }
 
+    def 'tasks should not be configured for ignored source sets'() {
+        given:
+        def scalaProject = buildScalaProject(null, ["bar"])
+        applyScalafixPlugin(scalaProject)
+        scalaProject.scalafix.ignoreSourceSets = [ "main", "bar" ]
+
+        when:
+        scalaProject.evaluate()
+
+        then:
+        !scalaProject.tasks.findByName('scalafixMain')
+        !scalaProject.tasks.findByName('checkScalafixMain')
+        !scalaProject.tasks.findByName('scalafixBar')
+        !scalaProject.tasks.findByName('checkScalafixBar')
+        scalaProject.tasks.findByName('scalafixTest')
+        scalaProject.tasks.findByName('checkScalafixTest')
+    }
+
     private applyScalafixPlugin(Project project,
                                 Boolean autoConfigureSemanticDb = false,
                                 String rules = '',


### PR DESCRIPTION
Some plugins (e.g. Scoverage) automatically create source sets that point to the same source files of other source sets. This causes the Scalafix plugin to be run twice against the same source files when users run a task that depends on the tasks for individual source sets (e.g. `check`, `checkScalafix` and `scalafix`).

This PR introduces an option in the Scalafix extension that users can use to exclude source sets from the plugin configuration.