### PR TITLE
defer task configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Example:
 ```
 scalafix {
     configFile = file("config/myscalafix.conf")
-    includes = ["**/com/**/*.scala"]
+    includes = ["/com/**/*.scala"]
     excludes = ["**/generated/**"]
     ignoreSourceSets = ["scoverage"]
     autoConfigureSemanticdb = false

--- a/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -1,8 +1,8 @@
 package io.github.cosmicsilence.scalafix
 
 import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.gradle.testkit.runner.internal.DefaultGradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 
@@ -17,10 +17,10 @@ class ScalafixPluginFunctionalTest extends Specification {
     private File scalafixConfFile
 
     def setup() {
-        settingsFile = testProjectDir.newFile("settings.gradle")
+        settingsFile = testProjectDir.newFile('settings.gradle')
         settingsFile.write "rootProject.name = 'hello-world'"
 
-        buildFile = testProjectDir.newFile("build.gradle")
+        buildFile = testProjectDir.newFile('build.gradle')
         buildFile.write '''
 plugins {
     id 'scala'
@@ -41,12 +41,12 @@ tasks.withType(ScalaCompile) {
 }
 '''
 
-        scalafixConfFile = testProjectDir.newFile(".scalafix.conf")
+        scalafixConfFile = testProjectDir.newFile('.scalafix.conf')
     }
 
-    def 'scalafixMain task runs compileScala by default'() {
+    def 'scalafixMain task should run compileScala by default'() {
         when:
-        BuildResult buildResult = runGradleTask('scalafix', ['-m'])
+        BuildResult buildResult = runGradle('scalafix', '-m')
 
         then:
         buildResult.output.contains(':compileScala SKIPPED')
@@ -55,13 +55,13 @@ tasks.withType(ScalaCompile) {
         buildResult.output.contains(':scalafixTest SKIPPED')
     }
 
-    def 'scalafixMain task runs compileScala when autoConfigureSemanticdb is enabled in the scalafix extension'() {
+    def 'scalafixMain task should run compileScala when autoConfigureSemanticdb is enabled in the scalafix extension'() {
         given:
         buildFile.append '''
 scalafix { autoConfigureSemanticdb = true }'''
 
         when:
-        BuildResult buildResult = runGradleTask('scalafix', ['-m'])
+        BuildResult buildResult = runGradle('scalafix', '-m')
 
         then:
         buildResult.output.contains(':compileScala SKIPPED')
@@ -70,13 +70,13 @@ scalafix { autoConfigureSemanticdb = true }'''
         buildResult.output.contains(':scalafixTest SKIPPED')
     }
 
-    def 'scalafixMain task does not run compileScala when autoConfigureSemanticdb is disabled in the scalafix extension'() {
+    def 'scalafixMain task should not run compileScala when autoConfigureSemanticdb is disabled in the scalafix extension'() {
         given:
         buildFile.append '''
 scalafix { autoConfigureSemanticdb = false }'''
 
         when:
-        BuildResult buildResult = runGradleTask('scalafix', ['-m'])
+        BuildResult buildResult = runGradle('scalafix', '-m')
 
         then:
         !buildResult.output.contains(':compileScala SKIPPED')
@@ -85,9 +85,9 @@ scalafix { autoConfigureSemanticdb = false }'''
         buildResult.output.contains(':scalafixTest SKIPPED')
     }
 
-    def 'checkScalafix task runs compileScala by default'() {
+    def 'checkScalafix task should run compileScala by default'() {
         when:
-        BuildResult buildResult = runGradleTask('checkScalafix', ['-m'])
+        BuildResult buildResult = runGradle('checkScalafix', '-m')
 
         then:
         buildResult.output.contains(':compileScala SKIPPED')
@@ -96,13 +96,13 @@ scalafix { autoConfigureSemanticdb = false }'''
         buildResult.output.contains(':checkScalafixTest SKIPPED')
     }
 
-    def 'checkScalafix task runs compileScala when autoConfigureSemanticdb is enabled in the scalafix extension'() {
+    def 'checkScalafix task should run compileScala when autoConfigureSemanticdb is enabled in the scalafix extension'() {
         given:
         buildFile.append '''
 scalafix { autoConfigureSemanticdb = true }'''
 
         when:
-        BuildResult buildResult = runGradleTask('checkScalafix', ['-m'])
+        BuildResult buildResult = runGradle('checkScalafix', '-m')
 
         then:
         buildResult.output.contains(':compileScala SKIPPED')
@@ -111,13 +111,13 @@ scalafix { autoConfigureSemanticdb = true }'''
         buildResult.output.contains(':checkScalafixTest SKIPPED')
     }
 
-    def 'checkScalafix task does not run compileScala when autoConfigureSemanticdb is disabled in the scalafix extension'() {
+    def 'checkScalafix task should not run compileScala when autoConfigureSemanticdb is disabled in the scalafix extension'() {
         given:
         buildFile.append '''
 scalafix { autoConfigureSemanticdb = false }'''
 
         when:
-        BuildResult buildResult = runGradleTask('checkScalafix', ['-m'])
+        BuildResult buildResult = runGradle('checkScalafix', '-m')
 
         then:
         !buildResult.output.contains(':compileScala SKIPPED')
@@ -126,7 +126,7 @@ scalafix { autoConfigureSemanticdb = false }'''
         buildResult.output.contains(':checkScalafixTest SKIPPED')
     }
 
-    def 'scalafix<SourceSet> task is created and runs compile<SourceSet>Scala by default when additional source set exists in the build script'() {
+    def 'scalafix<SourceSet> task should be created and run compile<SourceSet>Scala by default when additional source set exists in the build script'() {
         given:
         buildFile.append '''
 sourceSets {
@@ -134,7 +134,7 @@ sourceSets {
 }'''
 
         when:
-        BuildResult buildResult = runGradleTask('scalafix', ['-m'])
+        BuildResult buildResult = runGradle('scalafix', '-m')
 
         then:
         buildResult.output.contains(':compileScala SKIPPED')
@@ -145,7 +145,7 @@ sourceSets {
         buildResult.output.contains(':scalafixIntegTest SKIPPED')
     }
 
-    def 'checkScalafix<SourceSet> task is created and runs compile<SourceSet>Scala by default when additional source set exists in the build script'() {
+    def 'checkScalafix<SourceSet> task should be created and run compile<SourceSet>Scala by default when additional source set exists in the build script'() {
         given:
         buildFile.append '''
 sourceSets {
@@ -153,7 +153,7 @@ sourceSets {
 }'''
 
         when:
-        BuildResult buildResult = runGradleTask('checkScalafix', ['-m'])
+        BuildResult buildResult = runGradle('checkScalafix', '-m')
 
         then:
         buildResult.output.contains(':compileScala SKIPPED')
@@ -164,17 +164,154 @@ sourceSets {
         buildResult.output.contains(':checkScalafixIntegTest SKIPPED')
     }
 
+    def 'check task should run checkScalafix tasks but not scalafix'() {
+        when:
+        BuildResult buildResult = runGradle('check', '-m')
+
+        then:
+        buildResult.output.contains(':checkScalafixMain SKIPPED')
+        buildResult.output.contains(':checkScalafixTest SKIPPED')
+        buildResult.output.contains(':checkScalafix SKIPPED')
+        buildResult.output.contains(':check SKIPPED')
+        !buildResult.output.contains(':scalafix SKIPPED')
+        !buildResult.output.contains(':scalafixMain SKIPPED')
+        !buildResult.output.contains(':scalafixTest SKIPPED')
+    }
+
+    def 'all scalafix tasks should be grouped'() {
+        given:
+        buildFile.append '''
+sourceSets {
+    foo { }
+}'''
+
+        when:
+        BuildResult buildResult = runGradle('tasks')
+
+        then:
+        buildResult.output.contains(
+                """Scalafix tasks
+                  |--------------
+                  |checkScalafix - Fails if running Scalafix produces a diff or a linter error message. Won't write to files
+                  |checkScalafixFoo - Fails if running Scalafix produces a diff or a linter error message. Won't write to files in 'foo'
+                  |checkScalafixMain - Fails if running Scalafix produces a diff or a linter error message. Won't write to files in 'main'
+                  |checkScalafixTest - Fails if running Scalafix produces a diff or a linter error message. Won't write to files in 'test'
+                  |scalafix - Runs Scalafix on Scala sources
+                  |scalafixFoo - Runs Scalafix on Scala sources in 'foo'
+                  |scalafixMain - Runs Scalafix on Scala sources in 'main'
+                  |scalafixTest - Runs Scalafix on Scala sources in 'test'""".stripMargin())
+    }
+
+    def '*.semanticdb files should be created during compilation when autoConfigureSemanticdb is true and scalafix task is run'() {
+        given:
+        File mainSrc = createSourceFile('object Foo', 'main')
+        File testSrc = createSourceFile('object FooTest', 'test')
+        File buildDir = new File(testProjectDir.root, 'build')
+
+        when:
+        runGradle('scalafix')
+
+        then:
+        new File(buildDir, "classes/scala/main/META-INF/semanticdb/src/main/scala/dummy/${mainSrc.name}.semanticdb").exists()
+        new File(buildDir, "classes/scala/test/META-INF/semanticdb/src/test/scala/dummy/${testSrc.name}.semanticdb").exists()
+    }
+
+    def '*.semanticdb files should not be created during compilation when autoConfigureSemanticdb is false and scalafix task is run'() {
+        given:
+        buildFile.append '''
+scalafix { autoConfigureSemanticdb = false }'''
+        createSourceFile('object Foo', 'main')
+        createSourceFile('object FooTest', 'test')
+
+        when:
+        runGradle('scalafix')
+
+        then:
+        !new File(testProjectDir.root, 'build').exists()
+    }
+
+    def '*.semanticdb files should not be created during compilation when scalafix task is not run'() {
+        given:
+        createSourceFile('object Foo', 'main')
+        createSourceFile('object FooTest', 'test')
+        File buildDir = new File(testProjectDir.root, 'build')
+
+        when:
+        runGradle('compileScala', 'compileTestScala')
+
+        then:
+        buildDir.eachFileRecurse {
+            assert !it.name.endsWith('.semanticdb')
+        }
+    }
+
+    def 'scalafix task should not fail when no rules are informed'() {
+        given:
+        createSourceFile('object Foo')
+
+        when:
+        BuildResult buildResult = runGradle('scalafix')
+
+        then:
+        buildResult.output.contains '''
+> Task :scalafixMain
+No Scalafix rules to run'''
+        buildResult.output.contains 'BUILD SUCCESSFUL'
+    }
+
+    def 'checkScalafix task should not fail when no rules are informed'() {
+        given:
+        createSourceFile('object Foo')
+
+        when:
+        BuildResult buildResult = runGradle('checkScalafix')
+
+        then:
+        buildResult.output.contains '''
+> Task :checkScalafixMain
+No Scalafix rules to run'''
+        buildResult.output.contains 'BUILD SUCCESSFUL'
+    }
+
+    def 'scalafix task should not fail when there is no source file to be processed'() {
+        given:
+        scalafixConfFile.write 'rules = [ RemoveUnused ]'
+
+        when:
+        BuildResult buildResult = runGradle('scalafix')
+
+        then:
+        buildResult.output.contains ':scalafixMain NO-SOURCE'
+        buildResult.output.contains ':scalafixTest NO-SOURCE'
+        buildResult.output.contains ':scalafix UP-TO-DATE'
+        buildResult.output.contains 'BUILD SUCCESSFUL'
+    }
+
+    def 'checkScalafix task should not fail when there is no source file to be processed'() {
+        given:
+        scalafixConfFile.write 'rules = [ RemoveUnused ]'
+
+        when:
+        BuildResult buildResult = runGradle('checkScalafix')
+
+        then:
+        buildResult.output.contains ':checkScalafixMain NO-SOURCE'
+        buildResult.output.contains ':checkScalafixTest NO-SOURCE'
+        buildResult.output.contains ':checkScalafix UP-TO-DATE'
+        buildResult.output.contains 'BUILD SUCCESSFUL'
+    }
+
     def 'scalafix should run semantic rewrite rule and fix input source files'() {
         given:
-        scalafixConfFile.write "rules = [ RemoveUnused ]"
-        final File src = createSourceFile '''
+        scalafixConfFile.write 'rules = [ RemoveUnused ]'
+        File src = createSourceFile '''
 import scala.util.Random
 
 object HelloWorld
 '''
 
         when:
-        runGradleTask('scalafix', [ ])
+        runGradle('scalafix')
 
         then:
         src.getText() == '''
@@ -185,15 +322,15 @@ object HelloWorld
 
     def 'checkScalafix should run semantic rewrite rule and fail the build without fixing input source files'() {
         given:
-        scalafixConfFile.write "rules = [ RemoveUnused ]"
-        final File src = createSourceFile '''
+        scalafixConfFile.write 'rules = [ RemoveUnused ]'
+        File src = createSourceFile '''
 import scala.util.Random
 
 object HelloWorld
 '''
 
         when:
-        runGradleTask('checkScalafix', [ ])
+        runGradle('checkScalafix')
 
         then:
         // code is not changed on disk
@@ -202,27 +339,26 @@ import scala.util.Random
 
 object HelloWorld
 '''
-        final UnexpectedBuildFailure err = thrown()
-        err.message.contains("A file on disk does not match the file contents if it was fixed with Scalafix")
+        UnexpectedBuildFailure err = thrown()
+        err.message.contains('A file on disk does not match the file contents if it was fixed with Scalafix')
     }
-
 
     def 'scalafix should skip excluded source files'() {
         given:
-        scalafixConfFile.write "rules = [ RemoveUnused ]"
+        scalafixConfFile.write 'rules = [ RemoveUnused ]'
         buildFile.append '''
 scalafix {
-  excludes = ["**/scalafix/**"]
+  excludes = ["**/dummy/**"]
 }
 '''
-        final File src = createSourceFile '''
+        File src = createSourceFile '''
 import scala.util.Random
 
 object HelloWorld
 '''
 
         when:
-        runGradleTask('scalafix', [ ])
+        runGradle('scalafix')
 
         then:
         src.getText() == '''
@@ -231,7 +367,6 @@ import scala.util.Random
 object HelloWorld
 '''
     }
-
 
     def 'checkScalafix should skip excluded source files'() {
         given:
@@ -241,20 +376,20 @@ DisableSyntax.noVars = true
 '''
         buildFile.append '''
 scalafix {
-  excludes = ["**/scalafix/**"]
+  excludes = ["**/dummy/**"]
   autoConfigureSemanticdb = false
 }
 '''
-        final File src = createSourceFile '''
+        File src = createSourceFile '''
 object HelloWorld {
   var i: Int = 5
 }
 '''
         when:
-        final BuildResult buildResult = runGradleTask('checkScalafix', [ ])
+        BuildResult buildResult = runGradle('checkScalafix')
 
         then:
-        buildResult.output.contains("BUILD SUCCESSFUL")
+        buildResult.output.contains 'BUILD SUCCESSFUL'
         src.getText() == '''
 object HelloWorld {
   var i: Int = 5
@@ -273,14 +408,14 @@ scalafix {
   autoConfigureSemanticdb = false
 }
 '''
-        final File src = createSourceFile '''
+        File src = createSourceFile '''
 object HelloWorld {
   var msg: String = "hello, world!"
 }
 '''
 
         when:
-        runGradleTask('scalafix', [ ])
+        runGradle('scalafix')
 
         then:
         src.getText() == '''
@@ -288,11 +423,10 @@ object HelloWorld {
   var msg: String = "hello, world!"
 }
 '''
-        final UnexpectedBuildFailure err = thrown()
-        err.message.contains("A linter error was reported")
-        err.message.contains("error: [DisableSyntax.var] mutable state should be avoided")
+        UnexpectedBuildFailure err = thrown()
+        err.message.contains('A linter error was reported')
+        err.message.contains('error: [DisableSyntax.var] mutable state should be avoided')
     }
-
 
     def 'checkScalafix should run syntactic linter rule and fail the build if any violation is reported'() {
         given:
@@ -305,14 +439,14 @@ scalafix {
   autoConfigureSemanticdb = false
 }
 '''
-        final File src = createSourceFile '''
+        File src = createSourceFile '''
 object HelloWorld {
   var msg: String = "hello, world!"
 }
 '''
 
         when:
-        runGradleTask('checkScalafix', [ ])
+        runGradle('checkScalafix')
 
         then:
         src.getText() == '''
@@ -320,17 +454,15 @@ object HelloWorld {
   var msg: String = "hello, world!"
 }
 '''
-        final UnexpectedBuildFailure err = thrown()
-        err.message.contains("A linter error was reported")
-        err.message.contains("error: [DisableSyntax.var] mutable state should be avoided")
+        UnexpectedBuildFailure err = thrown()
+        err.message.contains('A linter error was reported')
+        err.message.contains('error: [DisableSyntax.var] mutable state should be avoided')
     }
-
-
 
     def 'scalafix should run semantic rewrite rule and leave wart-free code unchanged'() {
         given:
-        scalafixConfFile.write "rules = [ RemoveUnused ]"
-        final File src = createSourceFile '''
+        scalafixConfFile.write 'rules = [ RemoveUnused ]'
+        File src = createSourceFile '''
 import scala.util.Random
 
 object HelloWorld {
@@ -338,10 +470,10 @@ object HelloWorld {
 }
 '''
         when:
-        final BuildResult buildResult = runGradleTask('scalafix', [ ])
+        BuildResult buildResult = runGradle('scalafix')
 
         then:
-        buildResult.output.contains("BUILD SUCCESSFUL")
+        buildResult.output.contains 'BUILD SUCCESSFUL'
         src.getText() == '''
 import scala.util.Random
 
@@ -350,7 +482,6 @@ object HelloWorld {
 }
 '''
     }
-
 
     def 'checkScalafix should run syntactic linter rule and succeed if there are no violations'() {
         given:
@@ -363,16 +494,16 @@ scalafix {
   autoConfigureSemanticdb = false
 }
 '''
-        final File src = createSourceFile '''
+        File src = createSourceFile '''
 object HelloWorld {
   val i: Int = 3
 }
 '''
         when:
-        final BuildResult buildResult = runGradleTask('checkScalafix', [ ])
+        BuildResult buildResult = runGradle('checkScalafix')
 
         then:
-        buildResult.output.contains("BUILD SUCCESSFUL")
+        buildResult.output.contains 'BUILD SUCCESSFUL'
         src.getText() == '''
 object HelloWorld {
   val i: Int = 3
@@ -380,51 +511,96 @@ object HelloWorld {
 '''
     }
 
-
-    def 'all tasks should be grouped'() {
+    def 'scalafix should run single rule informed via command line even when it is not defined in the config file'() {
         given:
-        buildFile.append '''
-sourceSets {
-    foo { }
-}'''
-
+        File src = createSourceFile '''
+import scala.util.Random
+object Foo {
+  def proc { }
+}
+'''
         when:
-        BuildResult buildResult = runGradleTask('tasks', [])
+        BuildResult buildResult = runGradle('scalafix', '-Pscalafix.rules=ProcedureSyntax')
 
         then:
-        buildResult.output.contains(
-                """Scalafix tasks
-                  |--------------
-                  |checkScalafix - Fails if running Scalafix produces a diff or a linter error message. Won't write to files
-                  |checkScalafixFoo - Fails if running Scalafix produces a diff or a linter error message. Won't write to files in 'foo'
-                  |checkScalafixMain - Fails if running Scalafix produces a diff or a linter error message. Won't write to files in 'main'
-                  |checkScalafixTest - Fails if running Scalafix produces a diff or a linter error message. Won't write to files in 'test'
-                  |scalafix - Runs Scalafix on Scala sources
-                  |scalafixFoo - Runs Scalafix on Scala sources in 'foo'
-                  |scalafixMain - Runs Scalafix on Scala sources in 'main'
-                  |scalafixTest - Runs Scalafix on Scala sources in 'test'""".stripMargin())
+        buildResult.output.contains 'BUILD SUCCESSFUL'
+        src.getText() == '''
+import scala.util.Random
+object Foo {
+  def proc: Unit = { }
+}
+'''
     }
 
-    BuildResult runGradleTask(String task, List<String> arguments) {
-        arguments.add(task)
-        return GradleRunner.create()
+    def 'scalafix should run multiple rules informed via command line even when it is not defined in the config file'() {
+        given:
+        File src = createSourceFile '''
+import scala.util.Random
+object Foo {
+  def proc { }
+}
+'''
+        when:
+        BuildResult buildResult = runGradle('scalafix', '-Pscalafix.rules=ProcedureSyntax,RemoveUnused')
+
+        then:
+        buildResult.output.contains 'BUILD SUCCESSFUL'
+        src.getText() == '''
+object Foo {
+  def proc: Unit = { }
+}
+'''
+    }
+
+    def 'scalafix should only run rule informed via command line when there are other rules defined in the config file'() {
+        given:
+        scalafixConfFile.write '''
+rules = [
+  DisableSyntax
+  RemoveUnused
+  ProcedureSyntax
+]
+
+DisableSyntax.noVars = true
+'''
+        File src = createSourceFile '''
+import scala.util.Random
+object Foo {
+  var foo = "foo"
+  def proc { }
+}
+'''
+        when:
+        BuildResult buildResult = runGradle('scalafix', '-Pscalafix.rules=ProcedureSyntax')
+
+        then:
+        buildResult.output.contains 'BUILD SUCCESSFUL'
+        src.getText() == '''
+import scala.util.Random
+object Foo {
+  var foo = "foo"
+  def proc: Unit = { }
+}
+'''
+    }
+
+    private BuildResult runGradle(String... arguments) {
+        return new DefaultGradleRunner()
+                .withJvmArguments('-XX:MaxMetaspaceSize=500m')
                 .withProjectDir(testProjectDir.getRoot())
-                .withArguments(arguments)
-                .withGradleVersion(System.getProperty("compat.gradle.version"))
+                .withArguments(arguments.toList())
+                .withGradleVersion(System.getProperty('compat.gradle.version'))
                 .withPluginClasspath()
+                .forwardOutput()
                 .build()
     }
 
+    private File createSourceFile(String content, String sourceSet = 'main') {
+        def pkgFolder = new File(testProjectDir.root, "src/$sourceSet/scala/dummy")
 
-    /**
-     * Writes the given scala code to a file in a standard directory layout.
-     *
-     * @param content scala code.
-     * @return Written file containing the provided source code content.
-     */
-    private File createSourceFile(String content) {
-        final File scalaSrcDir = testProjectDir.newFolder("src", "main", "scala", "io", "github", "cosmicsilence", "scalafix")
-        final File scalaSrcFile = new File(scalaSrcDir.absolutePath +  "/package.scala")
+        if (!pkgFolder.exists()) pkgFolder.mkdirs()
+
+        def scalaSrcFile = new File(pkgFolder, "source_${new Random().nextInt(1000)}.scala")
         scalaSrcFile.write content
         scalaSrcFile
     }

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -71,7 +71,8 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        def compileScalaParameters = scalaProject.tasks.getByName('compileScala').scalaCompileOptions.additionalParameters
+        scalaProject.tasks.scalafixMain // force plugin configuration
+        def compileScalaParameters = scalaProject.tasks.compileScala.scalaCompileOptions.additionalParameters
         compileScalaParameters.containsAll(DEFAULT_COMPILER_OPTS + ['-Yrangepos', "-P:semanticdb:sourceroot:${scalaProject.projectDir}".toString()])
         compileScalaParameters.find {
             it.startsWith('-Xplugin:') &&
@@ -79,7 +80,8 @@ class ScalafixPluginTest extends Specification {
                     it.contains("scala-library-${BuildInfo.scala212Version}.jar")
         }
 
-        def compileTestScalaParameters = scalaProject.tasks.getByName('compileTestScala').scalaCompileOptions.additionalParameters
+        scalaProject.tasks.scalafixTest // force plugin configuration
+        def compileTestScalaParameters = scalaProject.tasks.compileTestScala.scalaCompileOptions.additionalParameters
         compileTestScalaParameters.containsAll(DEFAULT_COMPILER_OPTS + ['-Yrangepos', "-P:semanticdb:sourceroot:${scalaProject.projectDir}".toString()])
         compileTestScalaParameters.find {
             it.startsWith('-Xplugin:') &&
@@ -88,7 +90,7 @@ class ScalafixPluginTest extends Specification {
         }
     }
 
-    def 'Semanticdb configuration is not added if autoConfigureSemanticdb is set to false'() {
+    def 'SemanticDB configuration is not added if autoConfigureSemanticdb is set to false'() {
         given:
         applyScalafixPlugin(scalaProject, false)
 
@@ -96,8 +98,22 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        scalaProject.tasks.getByName('compileScala').scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
-        scalaProject.tasks.getByName('compileTestScala').scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
+        scalaProject.tasks.scalafixMain // force plugin configuration
+        scalaProject.tasks.compileScala.scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
+        scalaProject.tasks.scalafixTest // force plugin configuration
+        scalaProject.tasks.compileTestScala.scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
+    }
+
+    def 'SemanticDB configuration is not added if the scalafix task creation is deferred'() {
+        given:
+        applyScalafixPlugin(scalaProject, true)
+
+        when:
+        scalaProject.evaluate()
+
+        then:
+        scalaProject.tasks.compileScala.scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
+        scalaProject.tasks.compileTestScala.scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
     }
 
     def 'checkScalafix task configuration validation'() {
@@ -108,10 +124,10 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        Task task = scalaProject.tasks.getByName('checkScalafix')
+        def task = scalaProject.tasks.checkScalafix
         task.dependsOn.find { it.name == 'checkScalafixMain' }
         task.dependsOn.find { it.name == 'checkScalafixTest' }
-        scalaProject.tasks.getByName('check').dependsOn.find { it.name == 'checkScalafix' }
+        scalaProject.tasks.check.dependsOn.find { it.name == 'checkScalafix' }
     }
 
     def 'checkScalafixMain task configuration validation'() {
@@ -122,7 +138,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = scalaProject.tasks.checkScalafixMain
         task.dependsOn.isEmpty()
         task.mode == ScalafixMainMode.CHECK
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
@@ -150,7 +166,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = scalaProject.tasks.checkScalafixMain
         task.dependsOn.find{ it.name == 'compileScala' }
         task.mode == ScalafixMainMode.CHECK
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
@@ -179,7 +195,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixTest')
+        ScalafixTask task = scalaProject.tasks.checkScalafixTest
         task.dependsOn.isEmpty()
         task.mode == ScalafixMainMode.CHECK
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
@@ -207,7 +223,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixTest')
+        ScalafixTask task = scalaProject.tasks.checkScalafixTest
         task.dependsOn.find{ it.name == 'compileTestScala' }
         task.mode == ScalafixMainMode.CHECK
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
@@ -236,10 +252,10 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        Task task = scalaProject.tasks.getByName('scalafix')
+        Task task = scalaProject.tasks.scalafix
         task.dependsOn.find { it.name == 'scalafixMain' }
         task.dependsOn.find { it.name == 'scalafixTest' }
-        !scalaProject.tasks.getByName('check').dependsOn.find { it.name == 'scalafix' }
+        !scalaProject.tasks.check.dependsOn.find { it.name == 'scalafix' }
     }
 
     def 'scalafixMain task configuration validation'() {
@@ -250,7 +266,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
+        ScalafixTask task = scalaProject.tasks.scalafixMain
         task.dependsOn.isEmpty()
         task.mode == ScalafixMainMode.IN_PLACE
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
@@ -278,7 +294,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
+        ScalafixTask task = scalaProject.tasks.scalafixMain
         task.dependsOn.find { it.name == 'compileScala' }
         task.mode == ScalafixMainMode.IN_PLACE
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
@@ -307,7 +323,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('scalafixTest')
+        ScalafixTask task = scalaProject.tasks.scalafixTest
         task.dependsOn.isEmpty()
         task.mode == ScalafixMainMode.IN_PLACE
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
@@ -335,7 +351,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('scalafixTest')
+        ScalafixTask task = scalaProject.tasks.scalafixTest
         task.dependsOn.find { it.name == 'compileTestScala' }
         task.mode == ScalafixMainMode.IN_PLACE
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
@@ -365,9 +381,9 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('scalafixFoo')
+        ScalafixTask task = scalaProject.tasks.scalafixFoo
         task.dependsOn.isEmpty()
-        scalaProject.tasks.getByName('scalafix').dependsOn(task)
+        scalaProject.tasks.scalafix.dependsOn(task)
         task.mode == ScalafixMainMode.IN_PLACE
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
         task.sourceRoot == scalaProject.projectDir.path
@@ -397,9 +413,9 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('scalafixBar')
+        ScalafixTask task = scalaProject.tasks.scalafixBar
         task.dependsOn.find { it.name == 'compileBarScala' }
-        scalaProject.tasks.getByName('scalafix').dependsOn(task)
+        scalaProject.tasks.scalafix.dependsOn(task)
         task.mode == ScalafixMainMode.IN_PLACE
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
         task.sourceRoot == scalaProject.projectDir.path
@@ -430,9 +446,9 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixFoo')
+        ScalafixTask task = scalaProject.tasks.checkScalafixFoo
         task.dependsOn.isEmpty()
-        scalaProject.tasks.getByName('checkScalafix').dependsOn(task)
+        scalaProject.tasks.checkScalafix.dependsOn(task)
         task.mode == ScalafixMainMode.CHECK
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
         task.sourceRoot == scalaProject.projectDir.path
@@ -462,9 +478,9 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('checkScalafixBar')
+        ScalafixTask task = scalaProject.tasks.checkScalafixBar
         task.dependsOn.find { it.name == 'compileBarScala' }
-        scalaProject.tasks.getByName('checkScalafix').dependsOn(task)
+        scalaProject.tasks.checkScalafix.dependsOn(task)
         task.mode == ScalafixMainMode.CHECK
         task.configFile.get().asFile.path == "${scalaProject.projectDir}/.custom.conf"
         task.sourceRoot == scalaProject.projectDir.path
@@ -505,7 +521,7 @@ class ScalafixPluginTest extends Specification {
         subProject.evaluate()
 
         then:
-        ScalafixTask task = subProject.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = subProject.tasks.checkScalafixMain
         task.configFile.get().asFile.path == extensionConfig.path
     }
 
@@ -525,7 +541,7 @@ class ScalafixPluginTest extends Specification {
         subProject.evaluate()
 
         then:
-        ScalafixTask task = subProject.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = subProject.tasks.checkScalafixMain
         task.configFile.get().asFile.path == subProjectConfig.path
     }
 
@@ -542,7 +558,7 @@ class ScalafixPluginTest extends Specification {
         subProject.evaluate()
 
         then:
-        ScalafixTask task = subProject.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = subProject.tasks.checkScalafixMain
         task.configFile.get().asFile.path == rootProjectConfig.path
     }
 
@@ -556,7 +572,7 @@ class ScalafixPluginTest extends Specification {
         subProject.evaluate()
 
         then:
-        ScalafixTask task = subProject.tasks.getByName('checkScalafixMain')
+        ScalafixTask task = subProject.tasks.checkScalafixMain
         !task.configFile.get()
     }
 
@@ -569,7 +585,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
+        ScalafixTask task = scalaProject.tasks.scalafixMain
         task.source.files == [
                 new File(scalaProject.projectDir, "/src/main/scala/Cat.scala"),
                 new File(scalaProject.projectDir, "/src/main/scala/Duck.scala")
@@ -585,7 +601,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
+        ScalafixTask task = scalaProject.tasks.scalafixMain
         task.source.asPath == "${scalaProject.projectDir}/src/main/scala/Dog.scala"
     }
 
@@ -599,7 +615,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        ScalafixTask task = scalaProject.tasks.getByName('scalafixMain')
+        ScalafixTask task = scalaProject.tasks.scalafixMain
         task.source.asPath == "${scalaProject.projectDir}/src/main/scala/Duck.scala"
     }
 

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -124,7 +124,7 @@ class ScalafixPluginTest extends Specification {
         scalaProject.evaluate()
 
         then:
-        def task = scalaProject.tasks.checkScalafix
+        Task task = scalaProject.tasks.checkScalafix
         task.dependsOn.find { it.name == 'checkScalafixMain' }
         task.dependsOn.find { it.name == 'checkScalafixTest' }
         scalaProject.tasks.check.dependsOn.find { it.name == 'checkScalafix' }


### PR DESCRIPTION
Use the [configuration avoidance API](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) to prevent the SemanticDB compiler plugin from running in every project compilation if the Scalafix task is not run.