### PR TITLE
'Bump minor version of ch.epfl.scala:scalafix-interfaces to .26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation 'ch.epfl.scala:scalafix-interfaces:0.9.24'
+    implementation 'ch.epfl.scala:scalafix-interfaces:0.9.26'
     compatTestImplementation gradleTestKit()
     compatTestImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'

--- a/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -834,11 +834,13 @@ object OrganizeImportsTest
         '2.12.10'    || _
         '2.12.11'    || _
         '2.12.12'    || _
+        '2.12.13'    || _
         '2.13.0'     || _
         '2.13.1'     || _
         '2.13.2'     || _
         '2.13.3'     || _
         '2.13.4'     || _
+        '2.13.5'     || _
     }
 
     private BuildResult runGradle(TemporaryFolder projectDir, String... arguments) {

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPropsTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPropsTest.groovy
@@ -11,7 +11,7 @@ class ScalafixPropsTest extends Specification {
         def version = ScalafixProps.scalafixVersion
 
         then:
-        version == "0.9.24"
+        version == "0.9.26"
     }
 
     def 'it should return the Scalameta version'() {
@@ -19,7 +19,7 @@ class ScalafixPropsTest extends Specification {
         def version = ScalafixProps.scalametaVersion
 
         then:
-        version == "4.4.0"
+        version == "4.4.10"
     }
 
     def 'it should return the supported Scala 2.11.x version'() {
@@ -35,7 +35,7 @@ class ScalafixPropsTest extends Specification {
         def version = ScalafixProps.supportedScala212Version
 
         then:
-        version == "2.12.12"
+        version == "2.12.13"
     }
 
     def 'it should return the supported Scala 2.13.x version'() {
@@ -43,7 +43,7 @@ class ScalafixPropsTest extends Specification {
         def version = ScalafixProps.supportedScala213Version
 
         then:
-        version == "2.13.4"
+        version == "2.13.5"
     }
 
     @Unroll


### PR DESCRIPTION
Bumped minor version of ch.epfl.scala:scalafix-interfaces and updated tests.