### PR TITLE
temporarily downgrade reckon plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.ajoberstar.stutter' version '0.5.1'
+    id 'org.ajoberstar.reckon' version '0.11.0'
     id 'maven-publish'
     id 'com.gradle.plugin-publish' version '0.11.0'
     id 'groovy'
@@ -52,6 +53,11 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveClassifier = 'javadoc'
     from javadoc.destinationDir
+}
+
+reckon {
+    scopeFromProp()
+    stageFromProp('beta', 'rc', 'final')
 }
 
 pluginBundle {


### PR DESCRIPTION
Adding the `reckon` plugin back to fix the release build. It was removed in #63 as an attempt to overcome an error that started to show up:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'gradle-scalafix'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve org.ajoberstar.grgit:grgit-gradle:[4.0.0,5.0.0).
     Required by:
         project : > org.ajoberstar.reckon:org.ajoberstar.reckon.gradle.plugin:0.12.0 > org.ajoberstar.reckon:reckon-gradle:0.12.0
      > No matching variant of org.ajoberstar.grgit:grgit-gradle:5.0.0-rc.7 was found. The consumer was configured to find a runtime of a library compatible with Java 8, packaged as a jar, and its dependencies declared externally but:
          - Variant 'apiElements' capability org.ajoberstar.grgit:grgit-gradle:5.0.0-rc.7 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares an API of a component compatible with Java 11 and the consumer needed a runtime of a component compatible with Java 8
          - Variant 'javadocElements' capability org.ajoberstar.grgit:grgit-gradle:5.0.0-rc.7 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
          - Variant 'runtimeElements' capability org.ajoberstar.grgit:grgit-gradle:5.0.0-rc.7 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
          - Variant 'sourcesElements' capability org.ajoberstar.grgit:grgit-gradle:5.0.0-rc.7 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
```
