### PR TITLE
dropping support for Gradle 4.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ on Gradle projects. It supports both syntactic and semantic rules and lets you l
 &nbsp;
 ## Usage
 
-*Make sure you are using Gradle version 4.9 or later (except 5.0).*
+*Make sure you are using Gradle version 4.10 or later (except 5.0).*
 
 To use the Scalafix plugin, please include the following snippet in your build script:
 

--- a/src/test/groovy/io/github/cosmicsilence/compat/GradleCompatTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/compat/GradleCompatTest.groovy
@@ -17,7 +17,7 @@ class GradleCompatTest extends Specification {
 
     def 'isVersion4 should return true if the gradle version is 4.x'() {
         given:
-        gradle.gradleVersion >> '4.9'
+        gradle.gradleVersion >> '4.10.3'
 
         when:
         boolean isVersion4 = GradleCompat.isVersion4(mockProject)


### PR DESCRIPTION
```
    |   Caused by: java.lang.IncompatibleClassChangeError: Method 'scalafix.interfaces.Scalafix scalafix.interfaces.Scalafix.classloadInstance(java.lang.ClassLoader)' must be InterfaceMethodref constant
    |           at scalafix.interfaces.Scalafix$classloadInstance.call(Unknown Source)
    |           at io.github.cosmicsilence.scalafix.ScalafixTask.run(ScalafixTask.groovy:72)
    |           at jdk.internal.reflect.GeneratedMethodAccessor378.invoke(Unknown Source)
    |           at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    |           at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:73)
    |           at org.gradle.api.internal.project.taskfactory.StandardTaskAction.doExecute(StandardTaskAction.java:46)
    |           at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:39)
    |           at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:26)
    |           at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:786)
    |           at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:753)
    |           at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$1.run(ExecuteActionsTaskExecuter.java:131)
    |           at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:300)
    |           at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:292)
    |           at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:174)
    |           at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:90)
    |           at org.gradle.internal.operations.DelegatingBuildOperationExecutor.run(DelegatingBuildOperationExecutor.java:31)
    |           at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:120)
    |           at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:99)
    |           ... 31 more
```