### PR TITLE
Increase parallelisation of integration tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,6 +24,16 @@ jobs:
         java_version:
           - "8"
           - "11"
+        gradle_version:
+          - "4.10"
+          - "5.1.1"
+          - "5.6.4"
+          - "6.0.1"
+          - "6.9.4"
+          - "7.0.2"
+          - "7.6.3"
+          - "8.0.2"
+          - "8.4"
     steps:
       - name: Download repo
         uses: actions/checkout@v2
@@ -32,5 +42,5 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-      - name: Run Gradle compat tests for Java ${{ matrix.java_version }}
-        run: ./gradlew compatTestJava${{ matrix.java_version }}
+      - name: Run Gradle compat tests for Gradle ${{ matrix.gradle_version }} on Java ${{ matrix.java_version }}
+        run: ./gradlew compatTestJava${{ matrix.java_version }}Gradle${{ matrix.gradle_version }}

--- a/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -1,12 +1,13 @@
 package io.github.cosmicsilence.scalafix
 
-import org.gradle.internal.impldep.com.google.common.io.Files
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
 
 class ScalafixPluginFunctionalTest extends Specification {
@@ -861,7 +862,8 @@ object OrganizeImportsTest
     }
 
     private File createScalaProject(String additionalBuildInstructions = '', String scalaVersion = '2.13.12') {
-        File projectDir = Files.createTempDir()
+        File projectDir = Files.createTempDirectory("test").toFile()
+
         new File(projectDir, "build.gradle").write """
 plugins {
     id 'scala'


### PR DESCRIPTION
The integration tests are taking ~30 minutes to complete due to the number of Gradle and Java version combinations they are run against.