### PR TITLE
fix reckon plugin config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,10 @@ stutter {
 }
 
 reckon {
-    scopeFromProp()
-    stageFromProp('beta', 'rc', 'final')
+    defaultInferredScope = 'patch'
+    stages('beta', 'rc', 'final')
+    scopeCalc = calcScopeFromProp().or(calcScopeFromCommitMessages())
+    stageCalc = calcStageFromProp()
 }
 
 validatePlugins {


### PR DESCRIPTION
Before:
```
$ ./gradlew clean publishPluginMavenPublicationToMavenLocal
> Configure project :
Project version evaluated before reckon was configured. Run with --info to see cause.

$ ls ~/.m2/repository/io/github/cosmicsilence/gradle-scalafix
maven-metadata-local.xml unspecified
```

After:
```
$ ./gradlew clean publishPluginMavenPublicationToMavenLocal
> Configure project :
Reckoned version: 0.1.16-beta.0.3+20231029T085448Z

ls ~/.m2/repository/io/github/cosmicsilence/gradle-scalafix
0.1.16-beta.0.3+20231029T085448Z maven-metadata-local.xml
```