### PR TITLE
Enable caching across different machines

### DIFF
--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalaSourceSet.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalaSourceSet.groovy
@@ -27,6 +27,14 @@ class ScalaSourceSet {
         return sourceSet.name
     }
 
+    File getOutputDir() {
+        // Supported in Gradle >= 6.1
+        if (compileTask.hasProperty('destinationDirectory')) {
+            return compileTask.destinationDirectory.asFile.get()
+        }
+        return compileTask.destinationDir
+    }
+
     List<File> getFullClasspath() {
         return getClassesDirs() + getJarDependencies()
     }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalaSourceSet.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalaSourceSet.groovy
@@ -11,10 +11,16 @@ class ScalaSourceSet {
 
     private final Project project
     private final SourceSet sourceSet
+    private final ScalaCompile compileTask
 
     ScalaSourceSet(Project project, SourceSet sourceSet) {
+        if (!isScalaSourceSet(project, sourceSet)) {
+            throw new IllegalArgumentException(sourceSet.name + "is not a Scala source set")
+        }
+
         this.project = project
         this.sourceSet = sourceSet
+        this.compileTask = project.tasks.getByName(getCompileTaskName(sourceSet))
     }
 
     String getName() {
@@ -38,22 +44,34 @@ class ScalaSourceSet {
     }
 
     ScalaCompile getCompileTask() {
-        return project.tasks.getByName(getCompileTaskName(sourceSet))
+        return compileTask
     }
 
     @Memoized
     Optional<String> getScalaVersion() {
         def scalaRuntime = project.extensions.findByType(ScalaRuntime)
-        def scalaJar = scalaRuntime?.findScalaJar(getCompileTask().classpath, 'library')
+        def scalaJar = scalaRuntime?.findScalaJar(compileTask.classpath, 'library')
         return Optional.ofNullable(scalaJar ? scalaRuntime.getScalaVersion(scalaJar) : null)
     }
 
     List<String> getCompilerOptions() {
-        return getCompileTask().scalaCompileOptions.additionalParameters ?: []
+        return compileTask.scalaCompileOptions.additionalParameters ?: []
     }
 
     void addCompilerOptions(List<String> opts) {
-        getCompileTask().scalaCompileOptions.additionalParameters = getCompilerOptions() + opts
+        compileTask.scalaCompileOptions.additionalParameters = getCompilerOptions() + opts
+    }
+
+    void addCompilerPlugin(String pluginCoordinates) {
+        def dependency = project.dependencies.create(pluginCoordinates)
+        def configuration = project.configurations.detachedConfiguration(dependency).setTransitive(false)
+
+        // Supported in Gradle >= 6.4
+        if (compileTask.hasProperty('scalaCompilerPlugins')) {
+            compileTask.scalaCompilerPlugins = (compileTask.scalaCompilerPlugins ?: project.files()) + configuration
+        } else {
+            addCompilerOptions(['-Xplugin:' + configuration.asPath])
+        }
     }
 
     static boolean isScalaSourceSet(Project project, SourceSet sourceSet) {

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -85,7 +85,7 @@ class ScalafixPlugin implements Plugin<Project> {
                 // configures the semanticdb compiler plugin during the execution phase, but before the
                 // compile task is executed. This prevents dependencies from being resolved too early
                 sourceSet.getCompileTask().doFirst {
-                    configureSemanticdbCompilerPlugin(sourceSet, extension)
+                    configureSemanticdbCompilerPlugin(project, sourceSet, extension)
                 }
                 scalafixTask.dependsOn sourceSet.getCompileTask()
             }
@@ -94,19 +94,17 @@ class ScalafixPlugin implements Plugin<Project> {
         mainTask.dependsOn taskProvider
     }
 
-    private void configureSemanticdbCompilerPlugin(ScalaSourceSet sourceSet, ScalafixExtension extension) {
+    private void configureSemanticdbCompilerPlugin(Project project, ScalaSourceSet sourceSet, ScalafixExtension extension) {
         def scalaVersion = resolveScalaVersion(sourceSet)
         def semanticDbVersion = Optional.ofNullable(extension.semanticdb.version.orNull)
+        def relSourceRoot = sourceSet.getOutputDir().toPath().relativize(project.projectDir.toPath())
         sourceSet.addCompilerPlugin(ScalafixProps.getSemanticDbArtifactCoordinates(scalaVersion, semanticDbVersion))
         sourceSet.addCompilerOptions([
-                // Gradle does not use the project root as it's working directory. Instead, it has N workers that run
-                // under their own directories and point to the `scalac` task's output location (which is under the
-                // project). Setting `sourceroot` to `project.projectDir` is problematic for large code bases that
-                // require aggressive caching: any difference in compiler options between machines forces Gradle to
-                // recompile, rather than to download existing compiled artifacts. For that reason, we set `sourceroot`
-                // relative to `targetroot`. E.g.: `{proj_root}/build/classes/scala/{source_set}/` -> `{proj_root}/`.
-                // For more context, see: https://github.com/scalameta/scalameta/issues/2515
-                '-P:semanticdb:sourceroot:targetroot:../../../../',
+                // Setting `sourceroot` to the project's absolute path is problematic for large code bases that require
+                // aggressive caching: any difference in compiler options between machines forces Gradle to recompile,
+                // rather than to download existing compiled artifacts. For that reason, `sourceroot` is set relative
+                // to `targetroot`. For more context, see: https://github.com/scalameta/scalameta/issues/2515
+                '-P:semanticdb:sourceroot:targetroot:' + relSourceRoot,
                 '-Yrangepos'
         ])
     }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -85,7 +85,7 @@ class ScalafixPlugin implements Plugin<Project> {
                 // configures the semanticdb compiler plugin during the execution phase, but before the
                 // compile task is executed. This prevents dependencies from being resolved too early
                 sourceSet.getCompileTask().doFirst {
-                    configureSemanticdbCompilerPlugin(project, sourceSet, extension)
+                    configureSemanticdbCompilerPlugin(sourceSet, extension)
                 }
                 scalafixTask.dependsOn sourceSet.getCompileTask()
             }
@@ -94,25 +94,21 @@ class ScalafixPlugin implements Plugin<Project> {
         mainTask.dependsOn taskProvider
     }
 
-    private void configureSemanticdbCompilerPlugin(Project project, ScalaSourceSet sourceSet, ScalafixExtension extension) {
+    private void configureSemanticdbCompilerPlugin(ScalaSourceSet sourceSet, ScalafixExtension extension) {
         def scalaVersion = resolveScalaVersion(sourceSet)
         def semanticDbVersion = Optional.ofNullable(extension.semanticdb.version.orNull)
-        def semanticDbCoordinates = ScalafixProps.getSemanticDbArtifactCoordinates(scalaVersion, semanticDbVersion)
-        def semanticDbDependency = project.dependencies.create(semanticDbCoordinates)
-        def configuration = project.configurations.detachedConfiguration(semanticDbDependency).setTransitive(false)
-        def compilerOpts = [
-                '-Xplugin:' + configuration.asPath,
+        sourceSet.addCompilerPlugin(ScalafixProps.getSemanticDbArtifactCoordinates(scalaVersion, semanticDbVersion))
+        sourceSet.addCompilerOptions([
                 // Gradle does not use the project root as it's working directory. Instead, it has N workers that run
-                // under their own directories and point to the `scalac` task's output location (which is under the project).
-                // Setting `sourceroot` to `project.projectDir` is problematic for large code bases that require aggressive
-                // caching: any difference in compiler options between machines forces Gradle to recompile, rather than
-                // to download existing compiled artifacts. For that reason, we set `sourceroot` relative to `targetroot`
-                // (e.g. `{project_root}/build/classes/scala/{source_set}/` -> `{project_root}/`).
+                // under their own directories and point to the `scalac` task's output location (which is under the
+                // project). Setting `sourceroot` to `project.projectDir` is problematic for large code bases that
+                // require aggressive caching: any difference in compiler options between machines forces Gradle to
+                // recompile, rather than to download existing compiled artifacts. For that reason, we set `sourceroot`
+                // relative to `targetroot`. E.g.: `{proj_root}/build/classes/scala/{source_set}/` -> `{proj_root}/`.
                 // For more context, see: https://github.com/scalameta/scalameta/issues/2515
                 '-P:semanticdb:sourceroot:targetroot:../../../../',
                 '-Yrangepos'
-        ]
-        sourceSet.addCompilerOptions(compilerOpts)
+        ])
     }
 
     private String resolveScalaVersion(ScalaSourceSet sourceSet) {

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -345,7 +345,7 @@ class ScalafixPluginTest extends Specification {
         [compileMainTask, compileTestTask].each { task ->
             def compileOpts = task.scalaCompileOptions.additionalParameters
             assert compileOpts.containsAll(DEFAULT_COMPILER_OPTS)
-            assert compileOpts.containsAll(['-Yrangepos', '-P:semanticdb:sourceroot:targetroot:../../../../'])
+            assert compileOpts.containsAll(['-Yrangepos', '-P:semanticdb:sourceroot:targetroot:../../../..'])
             assert task.scalaCompilerPlugins.find {
                 it.absolutePath.endsWith("semanticdb-scalac_${SCALA_VERSION}-${ScalafixProps.scalametaVersion}.jar")
             }
@@ -374,7 +374,7 @@ class ScalafixPluginTest extends Specification {
 
         then:
         [compileMainTask, compileTestTask].each { task ->
-            assert task.scalaCompilerPlugins.find {it.absolutePath.endsWith(expectedSemanticdbJar) }
+            assert task.scalaCompilerPlugins.find { it.absolutePath.endsWith(expectedSemanticdbJar) }
         }
         scalafixMainTask.compileOptions.get() == compileMainTask.scalaCompileOptions.additionalParameters
         scalafixTestTask.compileOptions.get() == compileTestTask.scalaCompileOptions.additionalParameters

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -343,7 +343,7 @@ class ScalafixPluginTest extends Specification {
         [compileMainTask, compileTestTask].each { task ->
             def compileOpts = task.scalaCompileOptions.additionalParameters
             assert compileOpts.containsAll(DEFAULT_COMPILER_OPTS)
-            assert compileOpts.containsAll(['-Yrangepos', "-P:semanticdb:sourceroot:${scalaProject.projectDir}".toString()])
+            assert compileOpts.containsAll(['-Yrangepos', '-P:semanticdb:sourceroot:targetroot:../../../../'])
             assert compileOpts.find {
                 it.startsWith('-Xplugin:') &&
                         it.endsWith("semanticdb-scalac_${SCALA_VERSION}-${ScalafixProps.scalametaVersion}.jar") &&

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -318,7 +318,9 @@ class ScalafixPluginTest extends Specification {
         ScalafixTask scalafixTestTask = tasks.scalafixTest // forces plugin configuration
 
         then:
+        tasks.compileScala.scalaCompilerPlugins.empty
         tasks.compileScala.scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
+        tasks.compileTestScala.scalaCompilerPlugins.empty
         tasks.compileTestScala.scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
         scalafixMainTask.compileOptions.get() == DEFAULT_COMPILER_OPTS
         scalafixTestTask.compileOptions.get() == DEFAULT_COMPILER_OPTS
@@ -344,11 +346,10 @@ class ScalafixPluginTest extends Specification {
             def compileOpts = task.scalaCompileOptions.additionalParameters
             assert compileOpts.containsAll(DEFAULT_COMPILER_OPTS)
             assert compileOpts.containsAll(['-Yrangepos', '-P:semanticdb:sourceroot:targetroot:../../../../'])
-            assert compileOpts.find {
-                it.startsWith('-Xplugin:') &&
-                        it.endsWith("semanticdb-scalac_${SCALA_VERSION}-${ScalafixProps.scalametaVersion}.jar") &&
-                        !it.contains("scala-library")
+            assert task.scalaCompilerPlugins.find {
+                it.absolutePath.endsWith("semanticdb-scalac_${SCALA_VERSION}-${ScalafixProps.scalametaVersion}.jar")
             }
+            assert !task.scalaCompilerPlugins.find { it.name.contains("scala-library") }
         }
         scalafixMainTask.compileOptions.get() == compileMainTask.scalaCompileOptions.additionalParameters
         scalafixTestTask.compileOptions.get() == compileTestTask.scalaCompileOptions.additionalParameters
@@ -373,17 +374,15 @@ class ScalafixPluginTest extends Specification {
 
         then:
         [compileMainTask, compileTestTask].each { task ->
-            assert task.scalaCompileOptions.additionalParameters.find {
-                it.startsWith('-Xplugin:') && it.endsWith(expectedSemanticdbJar) && !it.contains("scala-library")
-            }
+            assert task.scalaCompilerPlugins.find {it.absolutePath.endsWith(expectedSemanticdbJar) }
         }
         scalafixMainTask.compileOptions.get() == compileMainTask.scalaCompileOptions.additionalParameters
         scalafixTestTask.compileOptions.get() == compileTestTask.scalaCompileOptions.additionalParameters
 
         where:
         semanticdbVersion   || expectedSemanticdbJar
-        '4.8.3'            || "semanticdb-scalac_${SCALA_VERSION}-${semanticdbVersion}.jar"
-        '4.8.4'            || "semanticdb-scalac_${SCALA_VERSION}-${semanticdbVersion}.jar"
+        '4.8.3'             || "semanticdb-scalac_${SCALA_VERSION}-${semanticdbVersion}.jar"
+        '4.8.4'             || "semanticdb-scalac_${SCALA_VERSION}-${semanticdbVersion}.jar"
     }
 
     def 'the semanticdb compiler plugin is not configured if semanticdb.autoConfigure is set to false'() {
@@ -403,7 +402,9 @@ class ScalafixPluginTest extends Specification {
         }
 
         then:
+        compileMainTask.scalaCompilerPlugins.empty
         compileMainTask.scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
+        compileTestTask.scalaCompilerPlugins.empty
         compileTestTask.scalaCompileOptions.additionalParameters == DEFAULT_COMPILER_OPTS
         scalafixMainTask.compileOptions.get() == DEFAULT_COMPILER_OPTS
         scalafixTestTask.compileOptions.get() == DEFAULT_COMPILER_OPTS


### PR DESCRIPTION
This PR addresses the issues reported in https://github.com/cosmicsilence/gradle-scalafix/issues/58#issuecomment-987490084 that were breaking caching across different machines:

1. Semanticdb compiler plugin configured via `-Xplugin`: The compiler plugin is now configured via the standard `scalaCompilerPlugins` property in the Scala compiler task (Gradle +6.4 only)
2. `-P:semanticdb:sourceroot` using an absolute path: Now the compiler option uses a path relative to `semanticdb:targetroot` (see https://github.com/scalameta/scalameta/issues/2515)