### PR TITLE
upgrade scalafix-interfaces to 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ on Gradle projects. It supports both syntactic and semantic rules and lets you l
 &nbsp;
 ## Compatibility
 
-- **Gradle:** `4.10` or later (except `5.0`)
-- **Scala:** `2.12.x` / `2.13.x` / `3.x` (requires [Gradle 7.3](https://docs.gradle.org/7.3/release-notes.html) or later)
+| Scala   | Gradle                                                                                   |
+|---------|------------------------------------------------------------------------------------------|
+| 2.12.x  | 4.10+ (except for `5.0`)                                                                 |
+| 2.13.x  | [6.0](https://github.com/cosmicsilence/gradle-scalafix/pull/85#issuecomment-2588144036)+ |
+| 3.x     | [7.3](https://docs.gradle.org/7.3/release-notes.html)+                                   |
+
 - **JDK:** `8` or later
 
 &nbsp;

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ java {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation 'ch.epfl.scala:scalafix-interfaces:0.12.1'
+    implementation 'ch.epfl.scala:scalafix-interfaces:0.13.0'
     compatTestImplementation gradleTestKit()
     compatTestImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-ch.epfl.scala:scalafix-interfaces:0.12.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-io.get-coursier:interface:1.0.19=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+ch.epfl.scala:scalafix-interfaces:0.13.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+io.get-coursier:interface:1.0.20=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.apiguardian:apiguardian-api:1.1.2=compatTestCompileClasspath,testCompileClasspath
 org.codehaus.groovy:groovy:3.0.12=compatTestCompileClasspath,compatTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.hamcrest:hamcrest:2.2=compatTestCompileClasspath,compatTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -12,8 +12,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class ScalafixPluginFunctionalTest extends Specification {
 
-    private static final String SCALA_2_VERSION = '2.13.12'
-    private static final String SCALA_3_VERSION = '3.3.1'
+    private static final String SCALA_2_VERSION = '2.13.16'
+    private static final String SCALA_3_VERSION = '3.3.4'
 
     def 'scalafixMain task should run compileScala by default'() {
         given:
@@ -825,12 +825,12 @@ object OrganizeImportsTest
 
         where:
         scalaVersion || _
-        '2.12.16'    || _
-        '2.12.17'    || _
         '2.12.18'    || _
-        '2.13.10'    || _
-        '2.13.11'    || _
-        '2.13.12'    || _
+        '2.12.19'    || _
+        '2.12.20'    || _
+        '2.13.14'    || _
+        '2.13.15'    || _
+        '2.13.16'    || _
     }
 
     @Unroll
@@ -897,7 +897,10 @@ trait OrganizeImportsTest(val x: String):
         '3.0.2'      || _
         '3.1.3'      || _
         '3.2.2'      || _
-        '3.3.1'      || _
+        '3.3.4'      || _
+        '3.4.3'      || _
+        '3.5.2'      || _
+        '3.6.2'      || _
     }
 
     def 'scalafix should load local rules from a subproject'() {

--- a/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -10,9 +10,12 @@ import spock.lang.Unroll
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 
+// needed for proper discovery of condition method
+import static io.github.cosmicsilence.scalafix.ScalafixPluginFunctionalTest.isScalaVersionSupported
+
 class ScalafixPluginFunctionalTest extends Specification {
 
-    private static final String SCALA_2_VERSION = '2.13.16'
+    private static final String SCALA_2_VERSION = '2.12.20'
     private static final String SCALA_3_VERSION = '3.3.4'
 
     def 'scalafixMain task should run compileScala by default'() {
@@ -783,6 +786,7 @@ object Foo {
     }
 
     @Unroll
+    @Requires({ isScalaVersionSupported(data.scalaVersion) })
     def 'scalafix should run built-in/external semantic and syntactic rules on Scala 2.x projects - #scalaVersion'() {
         given:
         def scalaBinaryVersion = scalaVersion.substring(0, scalaVersion.lastIndexOf('.'))
@@ -894,9 +898,6 @@ trait OrganizeImportsTest(val x: String):
 
         where:
         scalaVersion || _
-        '3.0.2'      || _
-        '3.1.3'      || _
-        '3.2.2'      || _
         '3.3.4'      || _
         '3.4.3'      || _
         '3.5.2'      || _
@@ -1018,6 +1019,17 @@ class BarDummyRule extends SemanticRule("BarDummyRule") {
 
     private static String gradleVersion() {
         return System.getProperty('compat.gradle.version')
+    }
+
+
+    private static boolean isScalaVersionSupported(String scalaVersion) {
+        return scalaVersion.startsWith("2.12")
+
+            // https://github.com/cosmicsilence/gradle-scalafix/pull/85#issuecomment-2588144036
+            || scalaVersion.startsWith("2.13") && gradleVersion() >= '6.0'
+
+            // https://docs.gradle.org/7.3/release-notes.html
+            || scalaVersion.startsWith("3") && gradleVersion() >= '7.3'
     }
 
     private static boolean isScala3Supported() {


### PR DESCRIPTION
This should fix the issue with using the plugin with Scala 2.13.16 (for which there is no semanticdb published at 0.9.3 version (used by scalafix 0.12.1)).

Unit tests passed locally.