### PR TITLE
fix-config-cache-errors

### DIFF
--- a/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -18,6 +18,17 @@ class ScalafixPluginFunctionalTest extends Specification {
     private static final String SCALA_2_VERSION = '2.12.20'
     private static final String SCALA_3_VERSION = '3.3.5'
 
+    def 'The scalafix plugin is applied successfully with no gradle configuration cache failures'() {
+        given:
+        File projectDir = createScalaProject()
+
+        when:
+        BuildResult buildResult = runGradle(projectDir, 'scalafix', '-m', '--configuration-cache')
+
+        then:
+        !buildResult.output.contains('ConfigurationCacheProblemsException')
+    }
+
     def 'scalafixMain task should run compileScala by default'() {
         given:
         File projectDir = createScalaProject()

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ConfigSemanticDbTask.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ConfigSemanticDbTask.groovy
@@ -1,39 +1,69 @@
 package io.github.cosmicsilence.scalafix
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.scala.ScalaCompile
+import java.nio.file.Path
 
 /** Configures the SemanticDB compiler plugin during the execution phase to avoid resolving dependencies too early. */
 class ConfigSemanticDbTask extends DefaultTask {
-
-    @Input
-    ScalaSourceSet sourceSet
-
     @Input
     final Property<String> scalaVersion = project.objects.property(String)
 
     @Input
     @Optional
-    String semanticDbVersion
+    final Property<String> semanticDbVersion = project.objects.property(String)
+
+    @Input
+    final Property<String> sourceSetName = project.objects.property(String)
+
+    @Input
+    final Property<String> projectDirPath = project.objects.property(String)
+
+    @Internal
+    final DirectoryProperty outputDir = project.objects.directoryProperty()
 
     @TaskAction
     void run() {
+        def compileTaskName = sourceSetName.get() == 'main' ? 'compileScala' : "compile${sourceSetName.get().capitalize()}Scala"
+        final ScalaCompile task = project.tasks.getByName(compileTaskName) as ScalaCompile
+
         if (isScala3()) {
             // It's currently not possible to set `-sourceroot` in a fully cache-friendly way (see comment below):
             // https://github.com/gradle/gradle/issues/27161
-            sourceSet.addCompilerOptions(['-Xsemanticdb', '-sourceroot', project.projectDir.absolutePath])
+            addCompilerOptions(task, ['-Xsemanticdb', '-sourceroot', projectDirPath.get()])
         } else {
-            def maybeSemanticDbVersion = java.util.Optional.ofNullable(semanticDbVersion)
-            sourceSet.addCompilerPlugin(ScalafixProps.getSemanticDbArtifactCoordinates(scalaVersion.get(), maybeSemanticDbVersion))
+            def maybeSemanticDbVersion = java.util.Optional.ofNullable(semanticDbVersion.getOrNull())
+            addCompilerPlugin(task, ScalafixProps.getSemanticDbArtifactCoordinates(scalaVersion.get(), maybeSemanticDbVersion))
+
             // Setting `sourceroot` to the project's absolute path is problematic for large code bases that require
             // aggressive caching: any difference in compiler options between machines forces Gradle to recompile,
             // rather than to download existing compiled artifacts. For that reason, `sourceroot` is set relative
             // to `targetroot`. For more context, see: https://github.com/scalameta/scalameta/issues/2515
-            def relSourceRoot = sourceSet.getOutputDir().toPath().relativize(project.projectDir.toPath())
-            sourceSet.addCompilerOptions(['-Yrangepos', '-P:semanticdb:sourceroot:targetroot:' + relSourceRoot])
+            Path relSourceRoot = outputDir.get().asFile.toPath().relativize(new File(projectDirPath.get()).toPath())
+            addCompilerOptions(task, ['-Yrangepos', '-P:semanticdb:sourceroot:targetroot:' + relSourceRoot])
+        }
+    }
+
+    private void addCompilerOptions(ScalaCompile task, List<String> opts) {
+        def currentOptions = task.scalaCompileOptions.additionalParameters ?: []
+        task.scalaCompileOptions.additionalParameters = currentOptions + opts
+    }
+
+    private void addCompilerPlugin(ScalaCompile task, String pluginCoordinates) {
+        def dependency = project.dependencies.create(pluginCoordinates)
+        def configuration = project.configurations.detachedConfiguration(dependency).setTransitive(false)
+
+        // Supported in Gradle >= 6.4
+        if (task.hasProperty('scalaCompilerPlugins')) {
+            task.scalaCompilerPlugins = (task.scalaCompilerPlugins ?: project.files()) + configuration
+        } else {
+            addCompilerOptions(task, ['-Xplugin:' + configuration.asPath])
         }
     }
 

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ConfigSemanticDbTaskTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ConfigSemanticDbTaskTest.groovy
@@ -23,8 +23,10 @@ class ConfigSemanticDbTaskTest extends Specification {
         ScalaCompile compileTask = project.tasks.compileScala
         SourceSet ss = project.sourceSets.main
         Task task = project.tasks.create('config', ConfigSemanticDbTask, {
-            sourceSet = new ScalaSourceSet(project, ss)
-            scalaVersion = '2.13.15'
+            sourceSetName.set(ss.name)
+            scalaVersion.set('2.13.15')
+            projectDirPath.set(project.projectDir.absolutePath)
+            outputDir.set(compileTask.destinationDirectory)
         })
 
         when:
@@ -46,9 +48,11 @@ class ConfigSemanticDbTaskTest extends Specification {
         ScalaCompile compileTask = project.tasks.compileScala
         SourceSet ss = project.sourceSets.main
         Task task = project.tasks.create('config', ConfigSemanticDbTask, {
-            sourceSet = new ScalaSourceSet(project, ss)
-            scalaVersion = '2.13.15'
-            semanticDbVersion = semanticdbVersion
+            sourceSetName.set(ss.name)
+            scalaVersion.set('2.13.15')
+            semanticDbVersion.set(semanticdbVersion)
+            projectDirPath.set(project.projectDir.absolutePath)
+            outputDir.set(compileTask.destinationDirectory)
         })
 
         when:
@@ -69,8 +73,10 @@ class ConfigSemanticDbTaskTest extends Specification {
         ScalaCompile compileTask = project.tasks.compileScala
         SourceSet ss = project.sourceSets.main
         Task task = project.tasks.create('config', ConfigSemanticDbTask, {
-            sourceSet = new ScalaSourceSet(project, ss)
-            scalaVersion = '3.3.1'
+            sourceSetName.set(ss.name)
+            scalaVersion.set('3.3.1')
+            projectDirPath.set(project.projectDir.absolutePath)
+            outputDir.set(compileTask.destinationDirectory)
         })
 
         when:

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -96,13 +96,13 @@ class ScalafixPluginTest extends Specification {
 
         then:
         ConfigSemanticDbTask mainTask = scalaProject.tasks.configSemanticDBMain
-        mainTask.sourceSet.name == 'main'
-        mainTask.semanticDbVersion == '4.8.3'
+        mainTask.sourceSetName.get() == 'main'
+        mainTask.semanticDbVersion.get() == '4.8.3'
         mainTask.scalaVersion.get() == SCALA_VERSION
 
         ConfigSemanticDbTask testTask = scalaProject.tasks.configSemanticDBTest
-        testTask.sourceSet.name == 'test'
-        testTask.semanticDbVersion == '4.8.3'
+        testTask.sourceSetName.get() == 'test'
+        testTask.semanticDbVersion.get() == '4.8.3'
         testTask.scalaVersion.get() == SCALA_VERSION
     }
 


### PR DESCRIPTION
Addressed comments and made tests pass based on this pr: https://github.com/cosmicsilence/gradle-scalafix/pull/84
Verified this is working by publishing locally, and importing into another project that uses this plugin + config cache

I had to make some additional changes in addition to the original pr, otherwise I was getting this kind of error in my project

```
Configuration cache entry discarded because incompatible tasks were found: 'task `:xxx:configSemanticDBTest` of type `io.github.cosmicsilence.scalafix.ConfigSemanticDbTask`', 'task `:xxx:configSemanticDBMain` of type `io.github.cosmicsilence.scalafix.ConfigSemanticDbTask`'.
```