### PR TITLE
upgrade scalafix-interfaces to 0.14.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ java {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation 'ch.epfl.scala:scalafix-interfaces:0.14.3'
+    implementation 'ch.epfl.scala:scalafix-interfaces:0.14.4'
     compatTestImplementation gradleTestKit()
     compatTestImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-ch.epfl.scala:scalafix-interfaces:0.14.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+ch.epfl.scala:scalafix-interfaces:0.14.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 io.get-coursier:interface:1.0.28=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.apiguardian:apiguardian-api:1.1.2=compatTestCompileClasspath,testCompileClasspath
 org.codehaus.groovy:groovy:3.0.12=compatTestCompileClasspath,compatTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath


### PR DESCRIPTION
https://github.com/scalacenter/scalafix/releases/tag/v0.14.4

This should fix the missing `semanticdb-scalac` errors with Scala 2.13.18.
`semanticdb` supports Scala 2.13.18 for 2.13.9+, and `scalafix` 0.14.4 switched to 2.13.10.