### PR TITLE
Drop Project references from extensions, helpers, and ScalafixTask

### DIFF
--- a/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
@@ -23,29 +23,28 @@ abstract class GradleCompat {
 
     static RegularFileProperty fileProperty(ObjectFactory objects, ProjectLayout layout, RegularFile defaultFile = null) {
         def fileProp = SUPPORTS_OBJECTS_FILE_PROPERTY ? objects.fileProperty() : layout.fileProperty()
-
         if (defaultFile != null) {
-            if (SUPPORTS_PROPERTY_CONVENTION) {
-                fileProp.convention(defaultFile)
-            } else {
-                fileProp.set(defaultFile)
-            }
+            setConvention(fileProp, defaultFile)
         }
-
         return fileProp
     }
 
     static Property<Boolean> booleanProperty(ObjectFactory objects, Boolean defaultBoolean = null) {
         def prop = objects.property(Boolean)
-
         if (defaultBoolean != null) {
-            if (SUPPORTS_PROPERTY_CONVENTION) {
-                prop.convention(defaultBoolean)
-            } else {
-                prop.set(defaultBoolean)
-            }
+            setConvention(prop, defaultBoolean)
         }
-
         return prop
+    }
+
+    static <T> Property<T> setConvention(Property<T> property, T value) {
+        // Property.convention() was added in Gradle 5.1; on older versions use .set() as a best-effort fallback
+        // (set() puts the property in the "explicit value" state, which user-supplied conventions cannot override).
+        if (SUPPORTS_PROPERTY_CONVENTION) {
+            property.convention(value)
+        } else {
+            property.set(value)
+        }
+        return property
     }
 }

--- a/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
@@ -1,23 +1,24 @@
 package io.github.cosmicsilence.compat
 
-import org.gradle.api.Project
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.util.GradleVersion
 
 abstract class GradleCompat {
 
+    private static final boolean IS_VERSION_4 = GradleVersion.current().version.startsWith("4.")
+
     private GradleCompat() {}
 
-    private static boolean isVersion4(Project project) {
-        return project.gradle.gradleVersion.startsWith("4.")
-    }
+    static RegularFileProperty fileProperty(ObjectFactory objects, ProjectLayout layout, RegularFile defaultFile = null) {
+        // ObjectFactory.fileProperty() was added in Gradle 5.0; on 4.x, fall back to ProjectLayout.fileProperty().
+        def fileProp = IS_VERSION_4 ? layout.fileProperty() : objects.fileProperty()
 
-    static RegularFileProperty fileProperty(Project project, RegularFile defaultFile = null) {
-        def fileProp = isVersion4(project) ? project.layout.fileProperty() : project.objects.fileProperty()
-
-        if (defaultFile) {
-            if (isVersion4(project)) {
+        if (defaultFile != null) {
+            if (IS_VERSION_4) {
                 fileProp.set(defaultFile)
             } else {
                 fileProp.convention(defaultFile)
@@ -27,17 +28,17 @@ abstract class GradleCompat {
         return fileProp
     }
 
-    static Property<Boolean> booleanProperty(Project project, Boolean defaultBoolean = null) {
-        def booleanProp = project.objects.property(Boolean)
+    static Property<Boolean> booleanProperty(ObjectFactory objects, Boolean defaultBoolean = null) {
+        def prop = objects.property(Boolean)
 
-        if (defaultBoolean) {
-            if (isVersion4(project)) {
-                booleanProp.set(project.provider { defaultBoolean })
+        if (defaultBoolean != null) {
+            if (IS_VERSION_4) {
+                prop.set(defaultBoolean)
             } else {
-                booleanProp.convention(defaultBoolean)
+                prop.convention(defaultBoolean)
             }
         }
 
-        return booleanProp
+        return prop
     }
 }

--- a/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
@@ -10,26 +10,25 @@ import org.gradle.util.GradleVersion
 
 abstract class GradleCompat {
 
-    private static final boolean IS_VERSION_4 = GradleVersion.current().version.startsWith("4.")
-    private static final boolean SUPPORTS_OBJECTS_FILE_COLLECTION =
-            GradleVersion.current().compareTo(GradleVersion.version("5.3")) >= 0
+    private static final GradleVersion CURRENT = GradleVersion.current()
+    private static final boolean SUPPORTS_OBJECTS_FILE_PROPERTY = CURRENT >= GradleVersion.version("5.0")
+    private static final boolean SUPPORTS_PROPERTY_CONVENTION = CURRENT >= GradleVersion.version("5.1")
+    private static final boolean SUPPORTS_OBJECTS_FILE_COLLECTION = CURRENT >= GradleVersion.version("5.3")
 
     private GradleCompat() {}
 
     static ConfigurableFileCollection fileCollection(ObjectFactory objects, ProjectLayout layout) {
-        // ObjectFactory.fileCollection() was added in Gradle 5.3; on older versions use ProjectLayout.configurableFiles().
         return SUPPORTS_OBJECTS_FILE_COLLECTION ? objects.fileCollection() : layout.configurableFiles()
     }
 
     static RegularFileProperty fileProperty(ObjectFactory objects, ProjectLayout layout, RegularFile defaultFile = null) {
-        // ObjectFactory.fileProperty() was added in Gradle 5.0; on 4.x, fall back to ProjectLayout.fileProperty().
-        def fileProp = IS_VERSION_4 ? layout.fileProperty() : objects.fileProperty()
+        def fileProp = SUPPORTS_OBJECTS_FILE_PROPERTY ? objects.fileProperty() : layout.fileProperty()
 
         if (defaultFile != null) {
-            if (IS_VERSION_4) {
-                fileProp.set(defaultFile)
-            } else {
+            if (SUPPORTS_PROPERTY_CONVENTION) {
                 fileProp.convention(defaultFile)
+            } else {
+                fileProp.set(defaultFile)
             }
         }
 
@@ -40,10 +39,10 @@ abstract class GradleCompat {
         def prop = objects.property(Boolean)
 
         if (defaultBoolean != null) {
-            if (IS_VERSION_4) {
-                prop.set(defaultBoolean)
-            } else {
+            if (SUPPORTS_PROPERTY_CONVENTION) {
                 prop.convention(defaultBoolean)
+            } else {
+                prop.set(defaultBoolean)
             }
         }
 

--- a/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
@@ -22,29 +22,26 @@ abstract class GradleCompat {
     }
 
     static RegularFileProperty fileProperty(ObjectFactory objects, ProjectLayout layout, RegularFile defaultFile = null) {
-        def fileProp = SUPPORTS_OBJECTS_FILE_PROPERTY ? objects.fileProperty() : layout.fileProperty()
-        if (defaultFile != null) {
-            setConvention(fileProp, defaultFile)
-        }
-        return fileProp
+        def prop = SUPPORTS_OBJECTS_FILE_PROPERTY ? objects.fileProperty() : layout.fileProperty()
+        return setConvention(prop, defaultFile)
     }
 
     static Property<Boolean> booleanProperty(ObjectFactory objects, Boolean defaultBoolean = null) {
         def prop = objects.property(Boolean)
-        if (defaultBoolean != null) {
-            setConvention(prop, defaultBoolean)
-        }
-        return prop
+        return setConvention(prop, defaultBoolean)
     }
 
-    static <T> Property<T> setConvention(Property<T> property, T value) {
+    static <T> Property<T> setConvention(Property<T> prop, T value) {
         // Property.convention() was added in Gradle 5.1; on older versions use .set() as a best-effort fallback
         // (set() puts the property in the "explicit value" state, which user-supplied conventions cannot override).
+        if (value == null) return prop
+
         if (SUPPORTS_PROPERTY_CONVENTION) {
-            property.convention(value)
+            prop.convention(value)
         } else {
-            property.set(value)
+            prop.set(value)
         }
-        return property
+
+        return prop
     }
 }

--- a/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/compat/GradleCompat.groovy
@@ -1,5 +1,6 @@
 package io.github.cosmicsilence.compat
 
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
@@ -10,8 +11,15 @@ import org.gradle.util.GradleVersion
 abstract class GradleCompat {
 
     private static final boolean IS_VERSION_4 = GradleVersion.current().version.startsWith("4.")
+    private static final boolean SUPPORTS_OBJECTS_FILE_COLLECTION =
+            GradleVersion.current().compareTo(GradleVersion.version("5.3")) >= 0
 
     private GradleCompat() {}
+
+    static ConfigurableFileCollection fileCollection(ObjectFactory objects, ProjectLayout layout) {
+        // ObjectFactory.fileCollection() was added in Gradle 5.3; on older versions use ProjectLayout.configurableFiles().
+        return SUPPORTS_OBJECTS_FILE_COLLECTION ? objects.fileCollection() : layout.configurableFiles()
+    }
 
     static RegularFileProperty fileProperty(ObjectFactory objects, ProjectLayout layout, RegularFile defaultFile = null) {
         // ObjectFactory.fileProperty() was added in Gradle 5.0; on 4.x, fall back to ProjectLayout.fileProperty().

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/Classloaders.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/Classloaders.groovy
@@ -1,7 +1,5 @@
 package io.github.cosmicsilence.scalafix
 
-import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import scalafix.interfaces.Scalafix
@@ -12,28 +10,26 @@ import java.util.concurrent.ConcurrentHashMap
 abstract class Classloaders {
 
     private static final Logger logger = Logging.getLogger(Classloaders)
-    private static final ConcurrentHashMap<Object, ClassLoader> cache = new ConcurrentHashMap<>()
+    private static final ConcurrentHashMap<String, ClassLoader> cache = new ConcurrentHashMap<>()
 
     private Classloaders() {}
 
-    static ClassLoader forScalafixCli(Project project, String scalafixCliCoordinates) {
-        return cache.computeIfAbsent(scalafixCliCoordinates, {
-            logger.debug("Creating classloader for '${scalafixCliCoordinates}'")
-            def cliDependency = project.dependencies.create(scalafixCliCoordinates)
-            def cliConfiguration = project.configurations.detachedConfiguration(cliDependency)
+    static ClassLoader forScalafixCli(Set<File> cliJars, String cacheKey) {
+        return cache.computeIfAbsent(cacheKey, {
+            logger.debug("Creating classloader for '${cacheKey}'")
             def parentClassloader = new ScalafixInterfacesClassloader(Scalafix.class.classLoader)
-            classloaderFrom(cliConfiguration, parentClassloader)
+            classloaderFrom(cliJars, parentClassloader)
         })
     }
 
-    static URLClassLoader forExternalRules(Configuration rulesConfiguration, ClassLoader scalafixCliClassloader) {
+    static URLClassLoader forExternalRules(Set<File> rulesJars, ClassLoader scalafixCliClassloader) {
         // No cache in this case as rules can be loaded from a subproject or source set under the same project.
         // There is no guarantee that rules would not be modified between executions.
-        return classloaderFrom(rulesConfiguration, scalafixCliClassloader)
+        return classloaderFrom(rulesJars, scalafixCliClassloader)
     }
 
-    private static URLClassLoader classloaderFrom(Configuration configuration, ClassLoader parent) {
-        def jarFiles = configuration.collect { it.toURI().toURL() }.toArray(new URL[0])
-        return new URLClassLoader(jarFiles, parent)
+    private static URLClassLoader classloaderFrom(Set<File> jars, ClassLoader parent) {
+        def jarUrls = jars.collect { it.toURI().toURL() }.toArray(new URL[0])
+        return new URLClassLoader(jarUrls, parent)
     }
 }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
@@ -53,7 +53,7 @@ class ScalafixExtension {
         includes = objects.setProperty(String)
         excludes = objects.setProperty(String)
         ignoreSourceSets = objects.setProperty(String)
-        semanticdb = objects.newInstance(SemanticdbParameters)
+        semanticdb = objects.newInstance(SemanticdbParameters, objects)
     }
 
     /**

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
@@ -44,11 +44,11 @@ class ScalafixExtension {
      */
     private final SemanticdbParameters semanticdb
 
-    private final ProjectLayout projectLayout
+    private final ProjectLayout layout
 
     @Inject
     ScalafixExtension(ObjectFactory objects, ProjectLayout layout) {
-        this.projectLayout = layout
+        this.layout = layout
         configFile = GradleCompat.fileProperty(objects, layout)
         includes = objects.setProperty(String)
         excludes = objects.setProperty(String)
@@ -63,7 +63,7 @@ class ScalafixExtension {
      * project's directory, in this order.
      */
     void setConfigFile(String path) {
-        configFile.set(projectLayout.projectDirectory.file(path))
+        configFile.set(layout.projectDirectory.file(path))
     }
 
     @Nested

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixExtension.groovy
@@ -1,16 +1,17 @@
 package io.github.cosmicsilence.scalafix
 
 import io.github.cosmicsilence.compat.GradleCompat
-import org.gradle.api.Project
-import org.gradle.api.file.RegularFile
+import org.gradle.api.Action
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 
-class ScalafixExtension {
+import javax.inject.Inject
 
-    private static final String DEFAULT_CONFIG_FILE = ".scalafix.conf"
+class ScalafixExtension {
 
     /**
      * Scalafix configuration file. If not specified, the plugin will try to find
@@ -43,22 +44,16 @@ class ScalafixExtension {
      */
     private final SemanticdbParameters semanticdb
 
-    private final Project project
+    private final ProjectLayout projectLayout
 
-    ScalafixExtension(Project project) {
-        this.project = project
-
-        RegularFile defaultRegularFile = locateConfigFile(project)?: locateConfigFile(project.rootProject)
-        configFile = GradleCompat.fileProperty(project, defaultRegularFile)
-        includes = project.objects.setProperty(String)
-        excludes = project.objects.setProperty(String)
-        ignoreSourceSets = project.objects.setProperty(String)
-        semanticdb = project.objects.newInstance(SemanticdbParameters, project)
-    }
-
-    private RegularFile locateConfigFile(Project project) {
-        RegularFile configFile = project.layout.projectDirectory.file(DEFAULT_CONFIG_FILE)
-        return (configFile.asFile.exists() && configFile.asFile.isFile()) ? configFile : null
+    @Inject
+    ScalafixExtension(ObjectFactory objects, ProjectLayout layout) {
+        this.projectLayout = layout
+        configFile = GradleCompat.fileProperty(objects, layout)
+        includes = objects.setProperty(String)
+        excludes = objects.setProperty(String)
+        ignoreSourceSets = objects.setProperty(String)
+        semanticdb = objects.newInstance(SemanticdbParameters)
     }
 
     /**
@@ -68,7 +63,7 @@ class ScalafixExtension {
      * project's directory, in this order.
      */
     void setConfigFile(String path) {
-        configFile.set(project.file(path))
+        configFile.set(projectLayout.projectDirectory.file(path))
     }
 
     @Nested
@@ -77,7 +72,7 @@ class ScalafixExtension {
         return semanticdb
     }
 
-    void semanticdb(Closure closure) {
-        project.configure(semanticdb, closure)
+    void semanticdb(Action<? super SemanticdbParameters> action) {
+        action.execute(semanticdb)
     }
 }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.RegularFile
 import org.gradle.api.plugins.scala.ScalaPlugin
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.SourceSet
@@ -18,18 +19,25 @@ class ScalafixPlugin implements Plugin<Project> {
 
     private static final String EXTENSION = "scalafix"
     private static final String EXT_RULES_CONFIGURATION = "scalafix"
+    private static final String SCALAFIX_CLI_CONFIGURATION_PREFIX = "scalafixCli"
     private static final String TASK_GROUP = "scalafix"
     private static final String FIX_TASK = "scalafix"
     private static final String CHECK_TASK = "checkScalafix"
     private static final String SEMANTIC_DB_TASK = "configSemanticDB"
     private static final String RULES_PROPERTY = "scalafix.rules"
+    private static final String DEFAULT_CONFIG_FILE = ".scalafix.conf"
 
     @Override
     void apply(Project project) {
-        def extension = project.extensions.create(EXTENSION, ScalafixExtension, project)
+        def extension = project.extensions.create(EXTENSION, ScalafixExtension)
         def configuration = project.configurations.create(EXT_RULES_CONFIGURATION, { Configuration cfg ->
             cfg.description = "Dependencies containing external Scalafix rules"
         })
+
+        RegularFile defaultConfig = locateDefaultConfigFile(project) ?: locateDefaultConfigFile(project.rootProject)
+        if (defaultConfig != null) {
+            extension.configFile.set(defaultConfig)
+        }
 
         project.afterEvaluate {
             if (!project.plugins.hasPlugin(ScalaPlugin)) {
@@ -66,9 +74,27 @@ class ScalafixPlugin implements Plugin<Project> {
                 onlyIf { configureSemanticDb.getOrElse(false) }
             })
             scalaSourceSet.getCompileTask().dependsOn semanticDbTask
-            configureScalafixTaskForSourceSet(project, scalaSourceSet, IN_PLACE, fixTask, extension, configuration, configureSemanticDb)
-            configureScalafixTaskForSourceSet(project, scalaSourceSet, CHECK, checkTask, extension, configuration, configureSemanticDb)
+
+            def cliCfg = createScalafixCliConfiguration(project, scalaSourceSet)
+            configureScalafixTaskForSourceSet(project, scalaSourceSet, IN_PLACE, fixTask, extension, configuration, cliCfg, configureSemanticDb)
+            configureScalafixTaskForSourceSet(project, scalaSourceSet, CHECK, checkTask, extension, configuration, cliCfg, configureSemanticDb)
         }
+    }
+
+    private Configuration createScalafixCliConfiguration(Project project, ScalaSourceSet sourceSet) {
+        def cfgName = SCALAFIX_CLI_CONFIGURATION_PREFIX + sourceSet.getName().capitalize()
+        def cliCfg = project.configurations.create(cfgName, { Configuration cfg ->
+            cfg.canBeConsumed = false
+            cfg.canBeResolved = true
+            cfg.visible = false
+            cfg.transitive = true
+            cfg.description = "Scalafix CLI dependencies for source set '${sourceSet.getName()}'"
+        })
+        cliCfg.withDependencies { deps ->
+            def scalaVersion = resolveScalaVersion(sourceSet)
+            deps.add(project.dependencies.create(ScalafixProps.getScalafixCliArtifactCoordinates(scalaVersion)))
+        }
+        return cliCfg
     }
 
     private void configureScalafixTaskForSourceSet(Project project,
@@ -77,6 +103,7 @@ class ScalafixPlugin implements Plugin<Project> {
                                                    Task parentTask,
                                                    ScalafixExtension extension,
                                                    Configuration extRulesConfiguration,
+                                                   Configuration scalafixCliConfiguration,
                                                    Property<Boolean> configureSemanticDb) {
         def taskName = parentTask.name + sourceSet.getName().capitalize()
         def scalafixTask = project.tasks.register(taskName, ScalafixTask, {
@@ -96,6 +123,8 @@ class ScalafixPlugin implements Plugin<Project> {
             scalaVersion.set(project.provider({ resolveScalaVersion(sourceSet) }))
             classpath.set(project.provider({ sourceSet.getFullClasspath().collect { it.path } }))
             compileOptions.set(project.provider({ sourceSet.getCompilerOptions() }))
+            scalafixCliClasspath.from(scalafixCliConfiguration)
+            toolClasspath.from(extRulesConfiguration)
             semanticDbConfigured = extension.semanticdb.autoConfigure.get()
 
             if (extension.semanticdb.autoConfigure.get()) {
@@ -108,6 +137,11 @@ class ScalafixPlugin implements Plugin<Project> {
         })
 
         parentTask.dependsOn scalafixTask
+    }
+
+    private static RegularFile locateDefaultConfigFile(Project project) {
+        RegularFile configFile = project.layout.projectDirectory.file(DEFAULT_CONFIG_FILE)
+        return (configFile.asFile.exists() && configFile.asFile.isFile()) ? configFile : null
     }
 
     private String resolveScalaVersion(ScalaSourceSet sourceSet) {

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -12,9 +12,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.SourceSet
 import scalafix.interfaces.ScalafixMainMode
 
-import static scalafix.interfaces.ScalafixMainMode.CHECK
-import static scalafix.interfaces.ScalafixMainMode.IN_PLACE
-
 /** Gradle plugin for running Scalafix */
 class ScalafixPlugin implements Plugin<Project> {
 
@@ -30,15 +27,15 @@ class ScalafixPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        def configuration = project.configurations.create(EXT_RULES_CONFIGURATION, { Configuration cfg ->
+        def extRulesConfiguration = project.configurations.create(EXT_RULES_CONFIGURATION, { Configuration cfg ->
             cfg.description = "Dependencies containing external Scalafix rules"
         })
 
         def extension = project.extensions.create(EXTENSION, ScalafixExtension, project.objects, project.layout)
-        RegularFile defaultConfig = locateDefaultConfigFile(project) ?: locateDefaultConfigFile(project.rootProject)
+        RegularFile defaultConfigFile = locateDefaultConfigFile(project) ?: locateDefaultConfigFile(project.rootProject)
 
-        if (defaultConfig != null) {
-            GradleCompat.setConvention(extension.configFile, defaultConfig)
+        if (defaultConfigFile != null) {
+            GradleCompat.setConvention(extension.configFile, defaultConfigFile)
         }
 
         project.afterEvaluate {
@@ -46,11 +43,11 @@ class ScalafixPlugin implements Plugin<Project> {
                 throw new GradleException("The 'scala' plugin must be applied")
             }
 
-            configureTasks(project, extension, configuration)
+            configureTasks(project, extension, extRulesConfiguration)
         }
     }
 
-    private void configureTasks(Project project, ScalafixExtension extension, Configuration configuration) {
+    private void configureTasks(Project project, ScalafixExtension extension, Configuration extRulesConfiguration) {
         def fixTask = project.tasks.create(FIX_TASK, {
             group = ScalafixPlugin.TASK_GROUP
             description = 'Runs Scalafix on Scala sources'
@@ -77,22 +74,32 @@ class ScalafixPlugin implements Plugin<Project> {
             })
             scalaSourceSet.getCompileTask().dependsOn semanticDbTask
 
-            def cliCfg = createScalafixCliConfiguration(project, scalaSourceSet)
-            configureScalafixTaskForSourceSet(project, scalaSourceSet, IN_PLACE, fixTask, extension, configuration, cliCfg, configureSemanticDb)
-            configureScalafixTaskForSourceSet(project, scalaSourceSet, CHECK, checkTask, extension, configuration, cliCfg, configureSemanticDb)
+            def cliConfiguration = createCliConfiguration(project, scalaSourceSet)
+            [[ScalafixMainMode.IN_PLACE, fixTask], [ScalafixMainMode.CHECK, checkTask]].each { mode, parentTask ->
+                configureScalafixTaskForSourceSet(
+                        project,
+                        scalaSourceSet,
+                        mode,
+                        parentTask,
+                        extension,
+                        extRulesConfiguration,
+                        cliConfiguration,
+                        configureSemanticDb
+                )
+            }
         }
     }
 
-    private Configuration createScalafixCliConfiguration(Project project, ScalaSourceSet sourceSet) {
+    private Configuration createCliConfiguration(Project project, ScalaSourceSet sourceSet) {
         def cfgName = SCALAFIX_CLI_CONFIGURATION_PREFIX + sourceSet.getName().capitalize()
-        def cliCfg = project.configurations.create(cfgName, { Configuration cfg ->
+        def cliConfiguration = project.configurations.create(cfgName, { Configuration cfg ->
             cfg.canBeConsumed = false
             cfg.canBeResolved = true
             cfg.visible = false
             cfg.transitive = true
             cfg.description = "Scalafix CLI dependencies for source set '${sourceSet.getName()}'"
         })
-        cliCfg.withDependencies { deps ->
+        cliConfiguration.withDependencies { deps ->
             try {
                 def scalaVersion = resolveScalaVersion(sourceSet)
                 deps.add(project.dependencies.create(ScalafixProps.getScalafixCliArtifactCoordinates(scalaVersion)))
@@ -102,7 +109,7 @@ class ScalafixPlugin implements Plugin<Project> {
                 // earlier during dependency resolution.
             }
         }
-        return cliCfg
+        return cliConfiguration
     }
 
     private void configureScalafixTaskForSourceSet(Project project,

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -31,12 +31,9 @@ class ScalafixPlugin implements Plugin<Project> {
             cfg.description = "Dependencies containing external Scalafix rules"
         })
 
-        def extension = project.extensions.create(EXTENSION, ScalafixExtension, project.objects, project.layout)
         RegularFile defaultConfigFile = locateDefaultConfigFile(project) ?: locateDefaultConfigFile(project.rootProject)
-
-        if (defaultConfigFile != null) {
-            GradleCompat.setConvention(extension.configFile, defaultConfigFile)
-        }
+        def extension = project.extensions.create(EXTENSION, ScalafixExtension, project.objects, project.layout)
+        GradleCompat.setConvention(extension.configFile, defaultConfigFile)
 
         project.afterEvaluate {
             if (!project.plugins.hasPlugin(ScalaPlugin)) {

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -29,7 +29,7 @@ class ScalafixPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        def extension = project.extensions.create(EXTENSION, ScalafixExtension)
+        def extension = project.extensions.create(EXTENSION, ScalafixExtension, project.objects, project.layout)
         def configuration = project.configurations.create(EXT_RULES_CONFIGURATION, { Configuration cfg ->
             cfg.description = "Dependencies containing external Scalafix rules"
         })

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -91,8 +91,14 @@ class ScalafixPlugin implements Plugin<Project> {
             cfg.description = "Scalafix CLI dependencies for source set '${sourceSet.getName()}'"
         })
         cliCfg.withDependencies { deps ->
-            def scalaVersion = resolveScalaVersion(sourceSet)
-            deps.add(project.dependencies.create(ScalafixProps.getScalafixCliArtifactCoordinates(scalaVersion)))
+            try {
+                def scalaVersion = resolveScalaVersion(sourceSet)
+                deps.add(project.dependencies.create(ScalafixProps.getScalafixCliArtifactCoordinates(scalaVersion)))
+            } catch (GradleException ignored) {
+                // Leave the configuration empty so the ScalafixTask reaches its action phase and reports the
+                // underlying error (unsupported / undetectable Scala version) from there instead of failing
+                // earlier during dependency resolution.
+            }
         }
         return cliCfg
     }

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixPlugin.groovy
@@ -1,5 +1,6 @@
 package io.github.cosmicsilence.scalafix
 
+import io.github.cosmicsilence.compat.GradleCompat
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -29,14 +30,15 @@ class ScalafixPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        def extension = project.extensions.create(EXTENSION, ScalafixExtension, project.objects, project.layout)
         def configuration = project.configurations.create(EXT_RULES_CONFIGURATION, { Configuration cfg ->
             cfg.description = "Dependencies containing external Scalafix rules"
         })
 
+        def extension = project.extensions.create(EXTENSION, ScalafixExtension, project.objects, project.layout)
         RegularFile defaultConfig = locateDefaultConfigFile(project) ?: locateDefaultConfigFile(project.rootProject)
+
         if (defaultConfig != null) {
-            extension.configFile.set(defaultConfig)
+            GradleCompat.setConvention(extension.configFile, defaultConfig)
         }
 
         project.afterEvaluate {

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
@@ -2,9 +2,12 @@ package io.github.cosmicsilence.scalafix
 
 import io.github.cosmicsilence.compat.GradleCompat
 import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
@@ -12,6 +15,7 @@ import scalafix.interfaces.Scalafix
 import scalafix.interfaces.ScalafixMainMode
 import scalafix.interfaces.ScalafixRule
 
+import javax.inject.Inject
 import java.nio.file.Paths
 
 class ScalafixTask extends SourceTask {
@@ -20,25 +24,25 @@ class ScalafixTask extends SourceTask {
 
     @InputFile
     @Optional
-    final RegularFileProperty configFile = GradleCompat.fileProperty(project)
+    final RegularFileProperty configFile
 
     @Input
     @Optional
-    final ListProperty<String> rules = project.objects.listProperty(String)
+    final ListProperty<String> rules
 
     @Input
     ScalafixMainMode mode
 
     @Input
-    final Property<String> scalaVersion = project.objects.property(String)
+    final Property<String> scalaVersion
 
     @Input
     @Optional
-    final ListProperty<String> compileOptions = project.objects.listProperty(String)
+    final ListProperty<String> compileOptions
 
     @Input
     @Optional
-    final ListProperty<String> classpath = project.objects.listProperty(String)
+    final ListProperty<String> classpath
 
     @Input
     String sourceRoot
@@ -46,11 +50,27 @@ class ScalafixTask extends SourceTask {
     @Internal
     Boolean semanticDbConfigured
 
+    @Classpath
+    final ConfigurableFileCollection scalafixCliClasspath
+
+    @Classpath
+    final ConfigurableFileCollection toolClasspath
+
+    @Inject
+    ScalafixTask(ObjectFactory objects, ProjectLayout layout) {
+        configFile = GradleCompat.fileProperty(objects, layout)
+        rules = objects.listProperty(String)
+        scalaVersion = objects.property(String)
+        compileOptions = objects.listProperty(String)
+        classpath = objects.listProperty(String)
+        scalafixCliClasspath = objects.fileCollection()
+        toolClasspath = objects.fileCollection()
+    }
+
     @TaskAction
     void run() {
         def sourcePaths = source.collect { it.toPath() }
         def configFilePath = java.util.Optional.ofNullable(configFile.orNull).map { it.asFile.toPath() }
-        def extRulesConfiguration = project.configurations.getByName(ScalafixPlugin.EXT_RULES_CONFIGURATION)
         def scalafixCliCoordinates = ScalafixProps.getScalafixCliArtifactCoordinates(scalaVersion.get())
 
         logger.info(
@@ -58,7 +78,7 @@ class ScalafixTask extends SourceTask {
                   | - Mode: ${mode}
                   | - Config file: ${configFilePath}
                   | - Scalafix cli artifact: ${scalafixCliCoordinates}
-                  | - External rules classpath: ${extRulesConfiguration.asPath}
+                  | - External rules classpath: ${toolClasspath.asPath}
                   | - Rules: ${rules.orNull}
                   | - Scala version: ${scalaVersion.get()}
                   | - Scalac options: ${compileOptions.orNull}
@@ -67,8 +87,8 @@ class ScalafixTask extends SourceTask {
                   | - Classpath: ${classpath.orNull}
                   |""".stripMargin())
 
-        def scalafixClassloader = Classloaders.forScalafixCli(project, scalafixCliCoordinates)
-        def externalRulesClassloader = Classloaders.forExternalRules(extRulesConfiguration, scalafixClassloader)
+        def scalafixClassloader = Classloaders.forScalafixCli(scalafixCliClasspath.files, scalafixCliCoordinates)
+        def externalRulesClassloader = Classloaders.forExternalRules(toolClasspath.files, scalafixClassloader)
         def scalafixArgs = Scalafix.classloadInstance(scalafixClassloader)
                 .newArguments()
                 .withMode(mode)

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/ScalafixTask.groovy
@@ -63,8 +63,8 @@ class ScalafixTask extends SourceTask {
         scalaVersion = objects.property(String)
         compileOptions = objects.listProperty(String)
         classpath = objects.listProperty(String)
-        scalafixCliClasspath = objects.fileCollection()
-        toolClasspath = objects.fileCollection()
+        scalafixCliClasspath = GradleCompat.fileCollection(objects, layout)
+        toolClasspath = GradleCompat.fileCollection(objects, layout)
     }
 
     @TaskAction

--- a/src/main/groovy/io/github/cosmicsilence/scalafix/SemanticdbParameters.groovy
+++ b/src/main/groovy/io/github/cosmicsilence/scalafix/SemanticdbParameters.groovy
@@ -1,7 +1,7 @@
 package io.github.cosmicsilence.scalafix
 
 import io.github.cosmicsilence.compat.GradleCompat
-import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 
 import javax.inject.Inject
@@ -22,8 +22,8 @@ class SemanticdbParameters {
     final Property<String> version
 
     @Inject
-    SemanticdbParameters(Project project) {
-        autoConfigure = GradleCompat.booleanProperty(project, true)
-        version = project.objects.property(String)
+    SemanticdbParameters(ObjectFactory objects) {
+        autoConfigure = GradleCompat.booleanProperty(objects, true)
+        version = objects.property(String)
     }
 }

--- a/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
+++ b/src/test/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginTest.groovy
@@ -415,6 +415,24 @@ class ScalafixPluginTest extends Specification {
         !task.configFile.isPresent()
     }
 
+    def 'scalafix lets the user override the default config file via convention'() {
+        given:
+        File defaultConfig = new File(scalaProject.projectDir, '.scalafix.conf')
+        defaultConfig.write 'rules = [Foo]'
+        File customConfig = new File(scalaProject.projectDir, '.custom.conf')
+        customConfig.write 'rules = [Bar]'
+
+        applyScalafixPlugin(scalaProject)
+        scalaProject.scalafix.configFile.convention(scalaProject.layout.projectDirectory.file('.custom.conf'))
+
+        when:
+        scalaProject.evaluate()
+
+        then:
+        ScalafixTask task = scalaProject.tasks.checkScalafixMain
+        task.configFile.get().asFile.path == customConfig.path
+    }
+
     def 'scalafix should only select sources matching include filter'() {
         given:
         applyScalafixPlugin(scalaProject)


### PR DESCRIPTION
## Summary

Preparatory refactor toward Configuration Cache support (issues #83, #96). No user-visible behavior change; all 48 existing unit tests pass.

- `ScalafixExtension`, `SemanticdbParameters` switch to `@Inject` constructors taking `ObjectFactory` / `ProjectLayout` instead of holding a `Project` field. Default `.scalafix.conf` lookup moves into the plugin.
- `ScalafixTask` uses an `@Inject` constructor and exposes `@Classpath` `scalafixCliClasspath` / `toolClasspath` `ConfigurableFileCollection`s. Its `@TaskAction` no longer calls `project.configurations.getByName(...)` or passes `project` to `Classloaders`.
- `Classloaders` now takes `Set<File>` instead of `Project` / `Configuration`. A per-source-set named `scalafixCli<SourceSet>` configuration (populated via `withDependencies` from the lazily-resolved Scala version) supplies the CLI jars at config time.

## Test plan

- [x] `./gradlew test` — all 48 unit tests pass
- [x] `./gradlew compatTest` — exercise the full Gradle compatibility matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)