### PR TITLE
upgrade scalafix-interfaces to 0.14.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ java {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation 'ch.epfl.scala:scalafix-interfaces:0.14.6'
+    implementation 'ch.epfl.scala:scalafix-interfaces:0.14.7'
     compatTestImplementation gradleTestKit()
     compatTestImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-ch.epfl.scala:scalafix-interfaces:0.14.6=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+ch.epfl.scala:scalafix-interfaces:0.14.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 io.get-coursier:interface:1.0.28=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.apiguardian:apiguardian-api:1.1.2=compatTestCompileClasspath,testCompileClasspath
 org.codehaus.groovy:groovy:3.0.12=compatTestCompileClasspath,compatTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
+++ b/src/compatTest/groovy/io/github/cosmicsilence/scalafix/ScalafixPluginFunctionalTest.groovy
@@ -442,7 +442,10 @@ object HelloWorld {
 
         then:
         src.getText() == '''
-import scala.collection.mutable.{ArrayBuffer, Buffer}
+import scala.collection.mutable.{
+  ArrayBuffer,
+  Buffer
+}
 
 object HelloWorld {
   def foo: Map[Int,String] = Map(1 -> "one")
@@ -870,7 +873,10 @@ object OrganizeImportsTest
         redundantSyntaxSource.getText() == 'object RedundantSyntaxTest'
         missingFinalSource.getText() == 'final case class MissingFinalTest(i: Int)'
         organizeImportsSource.getText() == '''
-import scala.collection.mutable.{ArrayBuffer, Buffer}
+import scala.collection.mutable.{
+  ArrayBuffer,
+  Buffer
+}
 object OrganizeImportsTest
 '''
 
@@ -938,7 +944,10 @@ final case class MissingFinalTest(i: Int):
     println("i < 0")
 '''
         organizeImportsSource.getText() == '''
-import scala.collection.mutable.{ArrayBuffer, Buffer}
+import scala.collection.mutable.{
+  ArrayBuffer,
+  Buffer
+}
 
 trait OrganizeImportsTest(val x: String):
   println(x)


### PR DESCRIPTION
Bumps `ch.epfl.scala:scalafix-interfaces` from `0.14.6` to `0.14.7` and updates the Gradle lockfile accordingly.

`scalafix` 0.14.7 introduced a behavior change in `OrganizeImports` (via PR scalacenter/scalafix#2427): it now uses scalameta's pretty-printer to reprint imports, which expands curly-brace import selectors to multiple lines. Three compat test expectations were updated to reflect the new format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)